### PR TITLE
Hotfix/remove log active session

### DIFF
--- a/src/main/java/org/example/VChatTalk/Service/SessionRegistry.java
+++ b/src/main/java/org/example/VChatTalk/Service/SessionRegistry.java
@@ -35,14 +35,7 @@ public class SessionRegistry {
     public Collection<WebSocketSession> getAllSessions(){
         return sessions.values();
     }
-    public int getSessionCount(){
-        return sessions.size();
-    }
-    public void logActiveSessions(){
-        StringBuilder sb = new StringBuilder();
-        for (WebSocketSession s : sessions.values()){
-            sb.append(s.getId()).append(s.isOpen() ? "[open]":"[close]").append(" ");
-        }
-        logger.info("Active Sessions ({}): {} ", getSessionCount(),sb.toString().trim()); ;
+    public void getSessionCount(){
+        logger.info("Active session({})", sessions.size());
     }
 }

--- a/src/main/java/org/example/VChatTalk/Service/SessionRegistry.java
+++ b/src/main/java/org/example/VChatTalk/Service/SessionRegistry.java
@@ -35,7 +35,7 @@ public class SessionRegistry {
     public Collection<WebSocketSession> getAllSessions(){
         return sessions.values();
     }
-    public void getSessionCount(){
-        logger.info("Active session({})", sessions.size());
+    public void countSessions(){
+        logger.info("Active sessions({})", sessions.size());
     }
 }

--- a/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
+++ b/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
@@ -23,7 +23,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         sessionRegistry.addSession(session);
         logger.info("New connection established. Session ID: {}", session.getId());
         session.sendMessage(new TextMessage("Welcome! You are connected to the chat server."));
-        sessionRegistry.getSessionCount();
+        sessionRegistry.countSessions();
 
     }
 
@@ -31,7 +31,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
         sessionRegistry.removeSession(session.getId());
         logger.info("Session disconnected: [{}] with status {}", session.getId(), status.getCode());
-        sessionRegistry.getSessionCount();
+        sessionRegistry.countSessions();
     }
 
     @Override

--- a/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
+++ b/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
@@ -23,7 +23,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         sessionRegistry.addSession(session);
         logger.info("New connection established. Session ID: {}", session.getId());
         session.sendMessage(new TextMessage("Welcome! You are connected to the chat server."));
-        sessionRegistry.logActiveSessions();
+        sessionRegistry.getSessionCount();
 
     }
 
@@ -31,7 +31,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
         sessionRegistry.removeSession(session.getId());
         logger.info("Session disconnected: [{}] with status {}", session.getId(), status.getCode());
-        sessionRegistry.logActiveSessions();
+        sessionRegistry.getSessionCount();
     }
 
     @Override


### PR DESCRIPTION
With member feedback, this method has been removed because there is no need to print the sessionId.