### PR TITLE
feat(private-chat): Implement session target context for 1-on-1 messaging (CHAT-014A)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,20 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>2.20.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>6.1.0-M1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.21.0</version>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
+++ b/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
@@ -84,7 +84,6 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                         // Remove target and reset to global or null
                         sessionRegistry.removeTarget(followerSessionId);
 
-                        // Send notification
                         sendSystem(followerSession, "User " + username + " has disconnected. Private chat ended.");
                     } catch (IOException e) {
                         log.error("Error sending disconnect notification: {}", e.getMessage());
@@ -92,6 +91,8 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                 }
             }
         }
+
+        sessionRegistry.removeTarget(sessionId);
 
         MessageDTO leaveMessage = chatService.handleLeave(sessionId);
 
@@ -237,6 +238,11 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                 }
 
                 case SELECT -> {
+                    if (!sessionRegistry.isUserRegistered(session.getId())) {
+                        sendError(session, "You must join the chat first! Use /join <username>");
+                        break;
+                    }
+
                     String targetUser = result.getTargetUsername();
                     String currentUser = sessionRegistry.getUsername(session.getId());
 
@@ -282,7 +288,8 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
 
                 case UNKNOWN -> {
                     dto.setType(MessageType.ERROR);
-                    dto.setContent(result.getError() != null ? result.getError() : "Invalid command. Type /help for assistance.");                    session.sendMessage(
+                    dto.setContent(result.getError() != null ? result.getError() : "Invalid command. Type /help for assistance.");
+                    session.sendMessage(
                             new TextMessage(mapper.writeValueAsString(dto))
                     );
                 }

--- a/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
+++ b/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
@@ -71,6 +71,27 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
 
         String sessionId = session.getId();
+        String username = sessionRegistry.getUsername(sessionId);
+
+        if (!"Anonymous".equals(username)) {
+            List<String> followers = sessionRegistry.getSessionsTargeting(username);
+
+            for (String followerSessionId : followers) {
+                WebSocketSession followerSession = sessionRegistry.findSessionById(followerSessionId);
+                // Check if online
+                if (followerSession != null && followerSession.isOpen()) {
+                    try {
+                        // Remove target and reset to global or null
+                        sessionRegistry.removeTarget(followerSessionId);
+
+                        // Send notification
+                        sendSystem(followerSession, "Người dùng " + username + " đã thoát. Chế độ chat riêng đã kết thúc.");
+                    } catch (IOException e) {
+                        log.error("Lỗi khi gửi thông báo thoát cho session {}: {}", followerSessionId, e.getMessage());
+                    }
+                }
+            }
+        }
 
         sessions.remove(session);
         lastMessageTime.remove(sessionId);
@@ -217,11 +238,25 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                 }
 
                 case SELECT -> {
-                    dto.setType(MessageType.SYSTEM);
-                    dto.setContent("Bạn đã chọn: " + result.getTargetUsername());
-                    session.sendMessage(
-                            new TextMessage(mapper.writeValueAsString(dto))
-                    );
+                    String targetUser = result.getTargetUsername();
+                    String currentUser = sessionRegistry.getUsername(session.getId());
+
+                    // Block chat with itself
+                    if (targetUser.equals(currentUser)) {
+                        sendError(session, "Bạn không thể chat riêng với chính mình!");
+                        break;
+                    }
+
+                    // check target is online
+                    if (sessionRegistry.isUserOnline(targetUser)) {
+                        sessionRegistry.setTarget(session.getId(), targetUser);
+
+                        dto.setType(MessageType.SYSTEM);
+                        dto.setContent("Đã chuyển sang chế độ chat riêng với: " + targetUser);
+                        session.sendMessage(new TextMessage(mapper.writeValueAsString(dto)));
+                    } else {
+                        sendError(session, "Người dùng '" + targetUser + "' không trực tuyến hoặc không tồn tại.");
+                    }
                 }
 
                 case LIST -> {

--- a/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
+++ b/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
@@ -85,21 +85,22 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                         sessionRegistry.removeTarget(followerSessionId);
 
                         // Send notification
-                        sendSystem(followerSession, "Người dùng " + username + " đã thoát. Chế độ chat riêng đã kết thúc.");
+                        sendSystem(followerSession, "User " + username + " has disconnected. Private chat ended.");
                     } catch (IOException e) {
-                        log.error("Lỗi khi gửi thông báo thoát cho session {}: {}", followerSessionId, e.getMessage());
+                        log.error("Error sending disconnect notification: {}", e.getMessage());
                     }
                 }
             }
         }
 
+        MessageDTO leaveMessage = chatService.handleLeave(sessionId);
+
         sessions.remove(session);
         lastMessageTime.remove(sessionId);
         sessionRegistry.removeSession(sessionId);
 
-        MessageDTO leave = chatService.handleLeave(sessionId);
-        if (leave != null) {
-            broadcast(leave, null);
+        if (leaveMessage != null) {
+            broadcast(leaveMessage, null);
         }
 
         log.info("[DISCONNECT] {} - {}", sessionId, status.getCode());
@@ -228,13 +229,12 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                    // do nothing
                 }
                 case HELP ->{
-                    String commands = "/help - Hiển thị các lệnh hiện có\n"
-                            + "/join <username> - Tham gia vào phòng chat\n"
-                            + "/send <message>- Gửi tin nhắn tới mọi người trong phòng chat\n"
-                            + "/list - Liệt kê các người dùng hiện tại\n"
-                            + "/select <name> - Chọn người dùng cụ thể\n"
-                            + "/exit - Thoát khỏi phòng chat\n";
-                    session.sendMessage(new TextMessage("Các lệnh hiện có:\n" + commands));
+                    String commands = "/help - Show available commands\n"
+                            + "/join <username> - Join the chat with a username\n"
+                            + "/list - List all online users\n"
+                            + "/select <name> - Select a user for private chat (1-on-1)\n"
+                            + "/exit - Disconnect from the server.\n";
+                    session.sendMessage(new TextMessage("Available commands:\n" + commands));
                 }
 
                 case SELECT -> {
@@ -243,7 +243,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
 
                     // Block chat with itself
                     if (targetUser.equals(currentUser)) {
-                        sendError(session, "Bạn không thể chat riêng với chính mình!");
+                        sendError(session, "You cannot chat with yourself!");
                         break;
                     }
 
@@ -252,10 +252,10 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                         sessionRegistry.setTarget(session.getId(), targetUser);
 
                         dto.setType(MessageType.SYSTEM);
-                        dto.setContent("Đã chuyển sang chế độ chat riêng với: " + targetUser);
+                        dto.setContent("Switched to private chat with: " + targetUser);
                         session.sendMessage(new TextMessage(mapper.writeValueAsString(dto)));
                     } else {
-                        sendError(session, "Người dùng '" + targetUser + "' không trực tuyến hoặc không tồn tại.");
+                        sendError(session, "User '" + targetUser + "' is offline or does not exist.");
                     }
                 }
 
@@ -283,8 +283,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
 
                 case UNKNOWN -> {
                     dto.setType(MessageType.ERROR);
-                    dto.setContent(result.getError() != null ? result.getError() : "❌ Lệnh không hợp lệ vui lòng nhập lại.");
-                    session.sendMessage(
+                    dto.setContent(result.getError() != null ? result.getError() : "Invalid command. Type /help for assistance.");                    session.sendMessage(
                             new TextMessage(mapper.writeValueAsString(dto))
                     );
                 }

--- a/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
+++ b/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
@@ -97,7 +97,6 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
 
         sessions.remove(session);
         lastMessageTime.remove(sessionId);
-        sessionRegistry.removeSession(sessionId);
 
         if (leaveMessage != null) {
             broadcast(leaveMessage, null);

--- a/src/main/java/org/example/VChatTalk/service/ChatService.java
+++ b/src/main/java/org/example/VChatTalk/service/ChatService.java
@@ -37,9 +37,15 @@ public class ChatService {
             throw new IllegalArgumentException("Username is too long (max 20 characters).");
         }
 
+        if (sessionRegistry.isUserOnline(name)) {
+            throw new IllegalArgumentException("Username '" + name + "' is already taken. Please choose another.");
+        }
+
         sessionRegistry.registerUser(sessionId, name);
 
-        return systemMessage(name + " joined the chat.");
+
+        int count = sessionRegistry.getAllSessions().size();
+        return systemMessage(name + " has join the chat. (Active: " + count + ")");
     }
 
     public MessageDTO handleMessage(String sessionId, MessageDTO dto) {
@@ -65,7 +71,8 @@ public class ChatService {
 
         String username = sessionRegistry.getUsername(sessionId);
         sessionRegistry.removeSession(sessionId);
-        return systemMessage(username + " has left the chat.");
+        int count = sessionRegistry.getAllSessions().size();
+        return systemMessage(username + " has left the chat. (Active: " + count + ")");
     }
 
     private MessageDTO systemMessage(String content) {

--- a/src/main/java/org/example/VChatTalk/service/ChatService.java
+++ b/src/main/java/org/example/VChatTalk/service/ChatService.java
@@ -37,15 +37,14 @@ public class ChatService {
             throw new IllegalArgumentException("Username is too long (max 20 characters).");
         }
 
-        if (sessionRegistry.isUserOnline(name)) {
+        boolean success = sessionRegistry.tryRegisterUser(sessionId, name);
+        if (!success) {
             throw new IllegalArgumentException("Username '" + name + "' is already taken. Please choose another.");
         }
 
-        sessionRegistry.registerUser(sessionId, name);
-
 
         int count = sessionRegistry.getAllSessions().size();
-        return systemMessage(name + " has join the chat. (Active: " + count + ")");
+        return systemMessage(name + " has joined the chat. (Total: " + count + ")");
     }
 
     public MessageDTO handleMessage(String sessionId, MessageDTO dto) {
@@ -72,7 +71,7 @@ public class ChatService {
         String username = sessionRegistry.getUsername(sessionId);
         sessionRegistry.removeSession(sessionId);
         int count = sessionRegistry.getAllSessions().size();
-        return systemMessage(username + " has left the chat. (Active: " + count + ")");
+        return systemMessage(username + " has left the chat. (Total: " + count + ")");
     }
 
     private MessageDTO systemMessage(String content) {

--- a/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
@@ -5,7 +5,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketSession;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
@@ -15,6 +17,8 @@ public class SessionRegistry {
 
     private final ConcurrentHashMap<String, String> sessionUsernames = new ConcurrentHashMap<>();
 
+    // Map target: key = sessionId, value = username
+    private final ConcurrentHashMap<String, String> sessionTargets = new ConcurrentHashMap<>();
 
     public void addSession(WebSocketSession session){
         if(session != null && session.getId()!=null){
@@ -57,5 +61,48 @@ public class SessionRegistry {
         logger.info("Active sessions({})", sessions.size());
     }
 
+    // Set target for current session
+    public void setTarget(String sessionId, String targetUsername) {
+        if (sessionId != null && targetUsername != null) {
+            sessionTargets.put(sessionId, targetUsername);
+        }
+    }
 
+    // Get target for current session
+    public String getTarget(String sessionId) {
+        return sessionTargets.get(sessionId);
+    }
+
+    // Remove target
+    public void removeTarget(String sessionId) {
+        if (sessionId != null) {
+            sessionTargets.remove(sessionId);
+        }
+    }
+
+    // Check user is online or offline
+    public boolean isUserOnline(String username) {
+        if (username == null){
+            return false;
+        }
+
+        return sessionUsernames.containsValue(username);
+    }
+
+    // Find list of sessionId is targeted to one username
+    public List<String> getSessionsTargeting (String targetUsername) {
+        List<String> targetingSessions = new ArrayList<>();
+
+        if (targetUsername == null) {
+            return targetingSessions;
+        }
+
+        sessionTargets.forEach((sessionId, target) -> {
+            if (target.equals(targetUsername)) {
+                targetingSessions.add(sessionId);
+            }
+        });
+
+        return targetingSessions;
+    }
 }

--- a/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
@@ -90,7 +90,7 @@ public class SessionRegistry {
         }
     }
 
-    // Check user is online or offline
+    // Check if user is online
     public boolean isUserOnline(String username) {
         if (username == null){
             return false;
@@ -100,13 +100,12 @@ public class SessionRegistry {
     }
 
     // Find list of sessionIds targeting a single username
-    public List<String> getSessionsTargeting (String targetUsername) {
+    public List<String> getSessionsTargeting(String targetUsername) {
         if (targetUsername == null) {
             return Collections.emptyList();
         }
 
         List<String> targetingSessions = new ArrayList<>();
-
 
         sessionTargets.forEach((sessionId, target) -> {
             if (target.equals(targetUsername)) {

--- a/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
@@ -7,6 +7,7 @@ import org.springframework.web.socket.WebSocketSession;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -91,11 +92,12 @@ public class SessionRegistry {
 
     // Find list of sessionId is targeted to one username
     public List<String> getSessionsTargeting (String targetUsername) {
+        if (targetUsername == null) {
+            return Collections.emptyList();
+        }
+
         List<String> targetingSessions = new ArrayList<>();
 
-        if (targetUsername == null) {
-            return targetingSessions;
-        }
 
         sessionTargets.forEach((sessionId, target) -> {
             if (target.equals(targetUsername)) {
@@ -103,6 +105,6 @@ public class SessionRegistry {
             }
         });
 
-        return targetingSessions;
+        return Collections.unmodifiableList(targetingSessions);
     }
 }

--- a/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
@@ -18,7 +18,7 @@ public class SessionRegistry {
 
     private final ConcurrentHashMap<String, String> sessionUsernames = new ConcurrentHashMap<>();
 
-    // Map target: key = sessionId, value = username
+    // Map of private chat targets: key = sessionId (who is targeting), value = targetUsername (who is being targeted)
     private final ConcurrentHashMap<String, String> sessionTargets = new ConcurrentHashMap<>();
 
     public void addSession(WebSocketSession session){
@@ -39,11 +39,15 @@ public class SessionRegistry {
         return sessionUsernames.getOrDefault(sessionId, "Anonymous");
     }
 
-    public void registerUser(String sessionId, String name) {
-        if (sessionId != null && name != null) {
-            sessionUsernames.put(sessionId, name);
-            logger.info("Registered user: {} with session: {}", name, sessionId);
+    public synchronized boolean tryRegisterUser(String sessionId, String username) {
+        if (sessionUsernames.containsValue(username)) {
+            return false;
         }
+
+        sessionUsernames.put(sessionId, username);
+
+        logger.info("Registered user: '{}' with session ID: {}", username, sessionId);
+        return true;
     }
 
     public WebSocketSession findSessionById(String sessionId){
@@ -52,9 +56,11 @@ public class SessionRegistry {
         }
         return sessions.get(sessionId);
     }
+
     public boolean isUserRegistered(String sessionId) {
         return sessionUsernames.containsKey(sessionId);
     }
+
     public Collection<WebSocketSession> getAllSessions(){
         return sessions.values();
     }
@@ -71,6 +77,9 @@ public class SessionRegistry {
 
     // Get target for current session
     public String getTarget(String sessionId) {
+        if (sessionId == null) {
+            return null;
+        }
         return sessionTargets.get(sessionId);
     }
 
@@ -90,7 +99,7 @@ public class SessionRegistry {
         return sessionUsernames.containsValue(username);
     }
 
-    // Find list of sessionId is targeted to one username
+    // Find list of sessionIds targeting a single username
     public List<String> getSessionsTargeting (String targetUsername) {
         if (targetUsername == null) {
             return Collections.emptyList();
@@ -107,4 +116,6 @@ public class SessionRegistry {
 
         return Collections.unmodifiableList(targetingSessions);
     }
+
+
 }

--- a/src/test/java/org/example/VChatTalk/handler/ChatWebSocketHandlerTest.java
+++ b/src/test/java/org/example/VChatTalk/handler/ChatWebSocketHandlerTest.java
@@ -40,15 +40,15 @@ class ChatWebSocketHandlerTest {
 
     @BeforeEach
     void setUp() {
-        // Mock leniently để tránh lỗi UnnecessaryStubbingException nếu test fail sớm
+        // Mock leniently to avoid UnnecessaryStubbingException if test fails early
         handler = new ChatWebSocketHandler(sessionRegistry, chatService, commandParserService);
         lenient().when(session.getId()).thenReturn("session-123");
     }
 
-    // [QUAN TRỌNG] Dọn dẹp session sau mỗi test để reset Rate Limit
+    // [IMPORTANT] Clean up session after each test to reset Rate Limit
     @AfterEach
     void tearDown() {
-        // Hàm này sẽ xóa session-123 khỏi map lastMessageTime
+        // This will remove session-123 from the lastMessageTime map
         handler.afterConnectionClosed(session, CloseStatus.NORMAL);
     }
 
@@ -62,7 +62,7 @@ class ChatWebSocketHandlerTest {
         when(sessionRegistry.isUserRegistered("session-123")).thenReturn(true);
         when(commandParserService.parse(command)).thenReturn(new CommandResult(CommandType.SELECT, targetName, null));
         when(sessionRegistry.getUsername("session-123")).thenReturn(senderName);
-        when(sessionRegistry.isUserOnline(targetName)).thenReturn(true);
+        when(sessionRegistry.isUserOnline(targetName)).thenReturn(true); // Updated to match renamed method
 
         // WHEN
         MessageDTO dto = new MessageDTO();
@@ -79,7 +79,7 @@ class ChatWebSocketHandlerTest {
         verify(session, atLeastOnce()).sendMessage(messageCaptor.capture());
 
         String sentMessage = messageCaptor.getValue().getPayload();
-        assertTrue(sentMessage.contains("Switched to private chat"), "Phải chứa thông báo thành công");
+        assertTrue(sentMessage.contains("Switched to private chat"), "Should contain success message");
     }
 
     @Test
@@ -105,7 +105,7 @@ class ChatWebSocketHandlerTest {
         verify(session).sendMessage(messageCaptor.capture());
         assertTrue(messageCaptor.getValue().getPayload().contains("offline") ||
                         messageCaptor.getValue().getPayload().contains("ERROR"),
-                "Phải báo lỗi user offline");
+                "Should report offline user error");
     }
 
     @Test
@@ -128,53 +128,52 @@ class ChatWebSocketHandlerTest {
 
         ArgumentCaptor<TextMessage> messageCaptor = ArgumentCaptor.forClass(TextMessage.class);
         verify(session).sendMessage(messageCaptor.capture());
-        assertTrue(messageCaptor.getValue().getPayload().contains("yourself"), "Phải báo lỗi chat với chính mình");
+        assertTrue(messageCaptor.getValue().getPayload().contains("yourself"), "Should report self-chat error");
     }
 
     @Test
     void testDisconnect_ShouldNotifyFollowersAndClearTarget() throws Exception {
-        // --- GIVEN (Chuẩn bị dữ liệu) ---
+        // --- GIVEN ---
 
-        // 1. Giả lập người thoát (Alice)
+        // 1. Simulate the leaver (Alice)
         String leaverSessionId = "session-Alice";
         String leaverName = "Alice";
         WebSocketSession leaverSession = mock(WebSocketSession.class);
         when(leaverSession.getId()).thenReturn(leaverSessionId);
 
-        // 2. Giả lập người đang chat với Alice (Bob - Follower)
+        // 2. Simulate the follower (Bob)
         String followerSessionId = "session-Bob";
         WebSocketSession followerSession = mock(WebSocketSession.class);
-        when(followerSession.isOpen()).thenReturn(true); // Bob đang online
+        when(followerSession.isOpen()).thenReturn(true); // Bob is online
 
-        // --- MOCKING BEHAVIOR (Giả lập hành vi Registry) ---
+        // --- MOCKING BEHAVIOR ---
 
-        // Khi hỏi tên của session thoát -> Trả về Alice
+        // Return Alice when asking for leaver's username
         when(sessionRegistry.getUsername(leaverSessionId)).thenReturn(leaverName);
 
-        // Khi hỏi "Ai đang target Alice?" -> Trả về list chứa Bob
-        // (Lưu ý: Dùng List.of hoặc Collections.singletonList)
+        // Return Bob when asking "Who is targeting Alice?"
         when(sessionRegistry.getSessionsTargeting(leaverName)).thenReturn(java.util.List.of(followerSessionId));
 
-        // Khi Handler tìm session object của Bob -> Trả về mock followerSession
+        // Return mock followerSession when Handler looks up Bob's session
         when(sessionRegistry.findSessionById(followerSessionId)).thenReturn(followerSession);
 
-        // --- WHEN (Thực hiện hành động) ---
-        // Gọi hàm ngắt kết nối cho Alice
+        // --- WHEN ---
+        // Call connection closed handler for Alice
         handler.afterConnectionClosed(leaverSession, CloseStatus.NORMAL);
 
-        // --- THEN (Kiểm tra kết quả) ---
+        // --- THEN ---
 
-        // 1. Verify: Phải xóa target của Bob đi (để Bob không chat với "ma" nữa)
+        // 1. Verify: Bob's target must be removed
         verify(sessionRegistry).removeTarget(followerSessionId);
 
-        // 2. Verify: Phải gửi tin nhắn thông báo cho Bob
+        // 2. Verify: Notification sent to Bob
         ArgumentCaptor<TextMessage> messageCaptor = ArgumentCaptor.forClass(TextMessage.class);
         verify(followerSession).sendMessage(messageCaptor.capture());
 
         String sentMessage = messageCaptor.getValue().getPayload();
-        // Kiểm tra nội dung tin nhắn (Tiếng Anh như đã sửa)
-        assertTrue(sentMessage.contains("Private chat ended"), "Bob phải nhận được thông báo kết thúc chat riêng");
-        assertTrue(sentMessage.contains(leaverName), "Thông báo phải chứa tên người vừa thoát");
+        // Verify message content
+        assertTrue(sentMessage.contains("Private chat ended"), "Bob should receive private chat ended notification");
+        assertTrue(sentMessage.contains(leaverName), "Notification should contain leaver's name");
     }
 
     @Test
@@ -182,11 +181,11 @@ class ChatWebSocketHandlerTest {
         // GIVEN
         String command = "/select Alice";
 
-        // [FIX]: Thêm lenient() để tránh lỗi UnnecessaryStubbing
-        // (Phòng trường hợp code check user trước khi parse hoặc ngược lại)
+        // [FIX]: Add lenient() to avoid UnnecessaryStubbingException
+        // (In case logic checks user registration before parsing command)
         lenient().when(sessionRegistry.isUserRegistered("session-123")).thenReturn(false);
 
-        // [FIX]: Thêm lenient() cho cả dòng parse này luôn cho chắc
+        // [FIX]: Add lenient() for parsing as well
         lenient().when(commandParserService.parse(command)).thenReturn(new CommandResult(CommandType.SELECT, "Alice", null));
 
         // WHEN
@@ -197,13 +196,14 @@ class ChatWebSocketHandlerTest {
         handler.handleTextMessage(session, new TextMessage(mapper.writeValueAsString(dto)));
 
         // THEN
-        // (Các verify bên dưới giữ nguyên)
+        // 1. Ensure setTarget is NEVER called
         verify(sessionRegistry, never()).setTarget(anyString(), anyString());
 
+        // 2. Should send error message
         ArgumentCaptor<TextMessage> messageCaptor = ArgumentCaptor.forClass(TextMessage.class);
         verify(session).sendMessage(messageCaptor.capture());
 
         String sentMessage = messageCaptor.getValue().getPayload();
-        assertTrue(sentMessage.contains("must join"), "Phải yêu cầu user join trước");
+        assertTrue(sentMessage.contains("must join"), "Should require user to join first");
     }
 }

--- a/src/test/java/org/example/VChatTalk/handler/ChatWebSocketHandlerTest.java
+++ b/src/test/java/org/example/VChatTalk/handler/ChatWebSocketHandlerTest.java
@@ -1,0 +1,133 @@
+package org.example.VChatTalk.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.VChatTalk.command.CommandParserService;
+import org.example.VChatTalk.command.CommandResult;
+import org.example.VChatTalk.command.CommandType;
+import org.example.VChatTalk.model.MessageDTO;
+import org.example.VChatTalk.model.MessageType;
+import org.example.VChatTalk.service.ChatService;
+import org.example.VChatTalk.util.SessionRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatWebSocketHandlerTest {
+
+    @Mock
+    private SessionRegistry sessionRegistry;
+    @Mock
+    private ChatService chatService;
+    @Mock
+    private CommandParserService commandParserService;
+    @Mock
+    private WebSocketSession session;
+
+    private ChatWebSocketHandler handler;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        // Mock leniently để tránh lỗi UnnecessaryStubbingException nếu test fail sớm
+        handler = new ChatWebSocketHandler(sessionRegistry, chatService, commandParserService);
+        lenient().when(session.getId()).thenReturn("session-123");
+    }
+
+    // [QUAN TRỌNG] Dọn dẹp session sau mỗi test để reset Rate Limit
+    @AfterEach
+    void tearDown() {
+        // Hàm này sẽ xóa session-123 khỏi map lastMessageTime
+        handler.afterConnectionClosed(session, CloseStatus.NORMAL);
+    }
+
+    @Test
+    void testSelect_ValidOnlineUser_ShouldSetTarget() throws Exception {
+        // GIVEN
+        String command = "/select Alice";
+        String senderName = "Bob";
+        String targetName = "Alice";
+
+        when(sessionRegistry.isUserRegistered("session-123")).thenReturn(true);
+        when(commandParserService.parse(command)).thenReturn(new CommandResult(CommandType.SELECT, targetName, null));
+        when(sessionRegistry.getUsername("session-123")).thenReturn(senderName);
+        when(sessionRegistry.isUserOnline(targetName)).thenReturn(true);
+
+        // WHEN
+        MessageDTO dto = new MessageDTO();
+        dto.setType(MessageType.MESSAGE);
+        dto.setContent(command);
+        String payload = mapper.writeValueAsString(dto);
+
+        handler.handleTextMessage(session, new TextMessage(payload));
+
+        // THEN
+        verify(sessionRegistry).setTarget("session-123", targetName);
+
+        ArgumentCaptor<TextMessage> messageCaptor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(session, atLeastOnce()).sendMessage(messageCaptor.capture());
+
+        String sentMessage = messageCaptor.getValue().getPayload();
+        assertTrue(sentMessage.contains("Switched to private chat"), "Phải chứa thông báo thành công");
+    }
+
+    @Test
+    void testSelect_OfflineUser_ShouldSendError() throws Exception {
+        // GIVEN
+        String targetName = "GhostUser";
+
+        when(sessionRegistry.isUserRegistered("session-123")).thenReturn(true);
+        when(commandParserService.parse(anyString())).thenReturn(new CommandResult(CommandType.SELECT, targetName, null));
+        when(sessionRegistry.getUsername("session-123")).thenReturn("Bob");
+        when(sessionRegistry.isUserOnline(targetName)).thenReturn(false);
+
+        // WHEN
+        MessageDTO dto = new MessageDTO();
+        dto.setType(MessageType.MESSAGE);
+        dto.setContent("/select GhostUser");
+        handler.handleTextMessage(session, new TextMessage(mapper.writeValueAsString(dto)));
+
+        // THEN
+        verify(sessionRegistry, never()).setTarget(anyString(), anyString());
+
+        ArgumentCaptor<TextMessage> messageCaptor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(session).sendMessage(messageCaptor.capture());
+        assertTrue(messageCaptor.getValue().getPayload().contains("offline") ||
+                        messageCaptor.getValue().getPayload().contains("ERROR"),
+                "Phải báo lỗi user offline");
+    }
+
+    @Test
+    void testSelect_Self_ShouldSendError() throws Exception {
+        // GIVEN
+        String myName = "Bob";
+
+        when(sessionRegistry.isUserRegistered("session-123")).thenReturn(true);
+        when(commandParserService.parse(anyString())).thenReturn(new CommandResult(CommandType.SELECT, myName, null));
+        when(sessionRegistry.getUsername("session-123")).thenReturn(myName);
+
+        // WHEN
+        MessageDTO dto = new MessageDTO();
+        dto.setType(MessageType.MESSAGE);
+        dto.setContent("/select Bob");
+        handler.handleTextMessage(session, new TextMessage(mapper.writeValueAsString(dto)));
+
+        // THEN
+        verify(sessionRegistry, never()).setTarget(anyString(), anyString());
+
+        ArgumentCaptor<TextMessage> messageCaptor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(session).sendMessage(messageCaptor.capture());
+        assertTrue(messageCaptor.getValue().getPayload().contains("yourself"), "Phải báo lỗi chat với chính mình");
+    }
+}

--- a/src/test/java/org/example/VChatTalk/handler/ChatWebSocketHandlerTest.java
+++ b/src/test/java/org/example/VChatTalk/handler/ChatWebSocketHandlerTest.java
@@ -130,4 +130,80 @@ class ChatWebSocketHandlerTest {
         verify(session).sendMessage(messageCaptor.capture());
         assertTrue(messageCaptor.getValue().getPayload().contains("yourself"), "Phải báo lỗi chat với chính mình");
     }
+
+    @Test
+    void testDisconnect_ShouldNotifyFollowersAndClearTarget() throws Exception {
+        // --- GIVEN (Chuẩn bị dữ liệu) ---
+
+        // 1. Giả lập người thoát (Alice)
+        String leaverSessionId = "session-Alice";
+        String leaverName = "Alice";
+        WebSocketSession leaverSession = mock(WebSocketSession.class);
+        when(leaverSession.getId()).thenReturn(leaverSessionId);
+
+        // 2. Giả lập người đang chat với Alice (Bob - Follower)
+        String followerSessionId = "session-Bob";
+        WebSocketSession followerSession = mock(WebSocketSession.class);
+        when(followerSession.isOpen()).thenReturn(true); // Bob đang online
+
+        // --- MOCKING BEHAVIOR (Giả lập hành vi Registry) ---
+
+        // Khi hỏi tên của session thoát -> Trả về Alice
+        when(sessionRegistry.getUsername(leaverSessionId)).thenReturn(leaverName);
+
+        // Khi hỏi "Ai đang target Alice?" -> Trả về list chứa Bob
+        // (Lưu ý: Dùng List.of hoặc Collections.singletonList)
+        when(sessionRegistry.getSessionsTargeting(leaverName)).thenReturn(java.util.List.of(followerSessionId));
+
+        // Khi Handler tìm session object của Bob -> Trả về mock followerSession
+        when(sessionRegistry.findSessionById(followerSessionId)).thenReturn(followerSession);
+
+        // --- WHEN (Thực hiện hành động) ---
+        // Gọi hàm ngắt kết nối cho Alice
+        handler.afterConnectionClosed(leaverSession, CloseStatus.NORMAL);
+
+        // --- THEN (Kiểm tra kết quả) ---
+
+        // 1. Verify: Phải xóa target của Bob đi (để Bob không chat với "ma" nữa)
+        verify(sessionRegistry).removeTarget(followerSessionId);
+
+        // 2. Verify: Phải gửi tin nhắn thông báo cho Bob
+        ArgumentCaptor<TextMessage> messageCaptor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(followerSession).sendMessage(messageCaptor.capture());
+
+        String sentMessage = messageCaptor.getValue().getPayload();
+        // Kiểm tra nội dung tin nhắn (Tiếng Anh như đã sửa)
+        assertTrue(sentMessage.contains("Private chat ended"), "Bob phải nhận được thông báo kết thúc chat riêng");
+        assertTrue(sentMessage.contains(leaverName), "Thông báo phải chứa tên người vừa thoát");
+    }
+
+    @Test
+    void testSelect_UnregisteredUser_ShouldSendError() throws Exception {
+        // GIVEN
+        String command = "/select Alice";
+
+        // [FIX]: Thêm lenient() để tránh lỗi UnnecessaryStubbing
+        // (Phòng trường hợp code check user trước khi parse hoặc ngược lại)
+        lenient().when(sessionRegistry.isUserRegistered("session-123")).thenReturn(false);
+
+        // [FIX]: Thêm lenient() cho cả dòng parse này luôn cho chắc
+        lenient().when(commandParserService.parse(command)).thenReturn(new CommandResult(CommandType.SELECT, "Alice", null));
+
+        // WHEN
+        MessageDTO dto = new MessageDTO();
+        dto.setType(MessageType.MESSAGE);
+        dto.setContent(command);
+
+        handler.handleTextMessage(session, new TextMessage(mapper.writeValueAsString(dto)));
+
+        // THEN
+        // (Các verify bên dưới giữ nguyên)
+        verify(sessionRegistry, never()).setTarget(anyString(), anyString());
+
+        ArgumentCaptor<TextMessage> messageCaptor = ArgumentCaptor.forClass(TextMessage.class);
+        verify(session).sendMessage(messageCaptor.capture());
+
+        String sentMessage = messageCaptor.getValue().getPayload();
+        assertTrue(sentMessage.contains("must join"), "Phải yêu cầu user join trước");
+    }
 }

--- a/src/test/java/org/example/VChatTalk/service/ChatServiceTest.java
+++ b/src/test/java/org/example/VChatTalk/service/ChatServiceTest.java
@@ -51,7 +51,7 @@ class ChatServiceTest {
 
     // Test Case 2: Successful registration (Happy Path)
     @Test
-    void testHandleJoin_ValidUsername_ShouldSuccess() {
+    void testHandleJoin_ValidUsername_ShouldSucceed() {
         // GIVEN
         String sessionId = "session-123";
         String newName = "Bob";

--- a/src/test/java/org/example/VChatTalk/service/ChatServiceTest.java
+++ b/src/test/java/org/example/VChatTalk/service/ChatServiceTest.java
@@ -1,0 +1,79 @@
+package org.example.VChatTalk.service;
+
+import org.example.VChatTalk.model.MessageDTO;
+import org.example.VChatTalk.util.SessionRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatServiceTest {
+
+    @Mock
+    private SessionRegistry sessionRegistry;
+
+    @InjectMocks
+    private ChatService chatService;
+
+    // TEST CASE 1: Đăng ký trùng tên (Race Condition Logic) -> Phải báo lỗi
+    @Test
+    void testHandleJoin_DuplicateUsername_ShouldThrowException() {
+        // GIVEN
+        String sessionId = "session-new-user";
+        String duplicateName = "Alice";
+
+        MessageDTO joinDto = new MessageDTO();
+        joinDto.setSender(duplicateName);
+
+        // 1. Giả lập user chưa join (hợp lệ ở bước check đầu)
+        when(sessionRegistry.isUserRegistered(sessionId)).thenReturn(false);
+
+        // 2. [QUAN TRỌNG] Giả lập tryRegisterUser trả về FALSE (tức là tên đã bị trùng)
+        when(sessionRegistry.tryRegisterUser(sessionId, duplicateName)).thenReturn(false);
+
+        // WHEN & THEN
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            chatService.handleJoin(sessionId, joinDto);
+        });
+
+        assertEquals("Username 'Alice' is already taken. Please choose another.", exception.getMessage());
+    }
+
+    // TEST CASE 2: Đăng ký thành công (Happy Path)
+    @Test
+    void testHandleJoin_ValidUsername_ShouldSuccess() {
+        // GIVEN
+        String sessionId = "session-123";
+        String newName = "Bob";
+        MessageDTO joinDto = new MessageDTO();
+        joinDto.setSender(newName);
+
+        when(sessionRegistry.isUserRegistered(sessionId)).thenReturn(false);
+        when(sessionRegistry.tryRegisterUser(sessionId, newName)).thenReturn(true);
+
+        // [FIX CHÍNH XÁC TẠI ĐÂY]
+        // Vì hàm getAllSessions() trả về Collection, ta dùng Collections.singletonList
+        // để tạo ra một Collection có size = 1 (chứa 1 session giả).
+        Collection<WebSocketSession> mockSessions = Collections.singletonList(mock(WebSocketSession.class));
+
+        // Bây giờ kiểu dữ liệu khớp hoàn toàn (Collection vs Collection)
+        when(sessionRegistry.getAllSessions()).thenReturn(mockSessions);
+
+        // WHEN
+        MessageDTO result = chatService.handleJoin(sessionId, joinDto);
+
+        // THEN
+        verify(sessionRegistry).tryRegisterUser(sessionId, newName);
+        assertEquals("Bob has joined the chat. (Total: 1)", result.getContent());
+    }
+}

--- a/src/test/java/org/example/VChatTalk/service/ChatServiceTest.java
+++ b/src/test/java/org/example/VChatTalk/service/ChatServiceTest.java
@@ -25,7 +25,7 @@ class ChatServiceTest {
     @InjectMocks
     private ChatService chatService;
 
-    // TEST CASE 1: Đăng ký trùng tên (Race Condition Logic) -> Phải báo lỗi
+    // Test Case 1: Duplicate username registration (Race Condition Logic) -> Should throw exception
     @Test
     void testHandleJoin_DuplicateUsername_ShouldThrowException() {
         // GIVEN
@@ -35,10 +35,10 @@ class ChatServiceTest {
         MessageDTO joinDto = new MessageDTO();
         joinDto.setSender(duplicateName);
 
-        // 1. Giả lập user chưa join (hợp lệ ở bước check đầu)
+        // Mock: User is not registered yet
         when(sessionRegistry.isUserRegistered(sessionId)).thenReturn(false);
 
-        // 2. [QUAN TRỌNG] Giả lập tryRegisterUser trả về FALSE (tức là tên đã bị trùng)
+        // Mock: tryRegisterUser returns FALSE (simulating race condition or taken name)
         when(sessionRegistry.tryRegisterUser(sessionId, duplicateName)).thenReturn(false);
 
         // WHEN & THEN
@@ -49,7 +49,7 @@ class ChatServiceTest {
         assertEquals("Username 'Alice' is already taken. Please choose another.", exception.getMessage());
     }
 
-    // TEST CASE 2: Đăng ký thành công (Happy Path)
+    // Test Case 2: Successful registration (Happy Path)
     @Test
     void testHandleJoin_ValidUsername_ShouldSuccess() {
         // GIVEN
@@ -61,12 +61,8 @@ class ChatServiceTest {
         when(sessionRegistry.isUserRegistered(sessionId)).thenReturn(false);
         when(sessionRegistry.tryRegisterUser(sessionId, newName)).thenReturn(true);
 
-        // [FIX CHÍNH XÁC TẠI ĐÂY]
-        // Vì hàm getAllSessions() trả về Collection, ta dùng Collections.singletonList
-        // để tạo ra một Collection có size = 1 (chứa 1 session giả).
+        // Mock getAllSessions returning a Collection (size = 1)
         Collection<WebSocketSession> mockSessions = Collections.singletonList(mock(WebSocketSession.class));
-
-        // Bây giờ kiểu dữ liệu khớp hoàn toàn (Collection vs Collection)
         when(sessionRegistry.getAllSessions()).thenReturn(mockSessions);
 
         // WHEN

--- a/src/test/java/org/example/VChatTalk/util/SessionRegistryTest.java
+++ b/src/test/java/org/example/VChatTalk/util/SessionRegistryTest.java
@@ -1,0 +1,103 @@
+package org.example.VChatTalk.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SessionRegistryTest {
+
+    private SessionRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        // Khởi tạo mới Registry trước mỗi bài test để dữ liệu sạch sẽ
+        registry = new SessionRegistry();
+    }
+
+    // 1. Test vòng đời cơ bản: Set -> Get -> Remove
+    @Test
+    void testTargetLifecycle() {
+        String sessionId = "s1";
+        String targetName = "Alice";
+
+        // Ban đầu chưa có gì
+        assertNull(registry.getTarget(sessionId));
+
+        // SET
+        registry.setTarget(sessionId, targetName);
+        assertEquals(targetName, registry.getTarget(sessionId), "Sau khi set, get phải ra đúng tên");
+
+        // REMOVE
+        registry.removeTarget(sessionId);
+        assertNull(registry.getTarget(sessionId), "Sau khi remove, get phải ra null");
+    }
+
+    // 2. Test Reverse Lookup (Tìm ngược): Ai đang nhắm vào user này?
+    @Test
+    void testGetSessionsTargeting() {
+        // Kịch bản: s1 và s2 cùng chat với Alice, s3 chat với Bob
+        registry.setTarget("s1", "Alice");
+        registry.setTarget("s2", "Alice");
+        registry.setTarget("s3", "Bob");
+
+        // Kiểm tra danh sách người đang chat với Alice
+        List<String> followersAlice = registry.getSessionsTargeting("Alice");
+
+        assertEquals(2, followersAlice.size(), "Phải có 2 người đang chat với Alice");
+        assertTrue(followersAlice.contains("s1"));
+        assertTrue(followersAlice.contains("s2"));
+
+        // Kiểm tra danh sách người đang chat với Bob
+        List<String> followersBob = registry.getSessionsTargeting("Bob");
+        assertEquals(1, followersBob.size());
+        assertTrue(followersBob.contains("s3"));
+
+        // Kiểm tra người không ai chat cùng
+        List<String> followersNobody = registry.getSessionsTargeting("Charlie");
+        assertTrue(followersNobody.isEmpty());
+    }
+
+    // 3. Test check Online/Offline
+    @Test
+    void testIsUserOnline() {
+        String sessionId = "s1";
+        String username = "Alice";
+
+        // Ban đầu offline
+        assertFalse(registry.isUserOnline(username));
+
+        // Đăng ký user (Sử dụng hàm tryRegisterUser mà bạn vừa thêm)
+        registry.tryRegisterUser(sessionId, username);
+
+        // Bây giờ phải Online
+        assertTrue(registry.isUserOnline(username));
+
+        // Check tên lung tung -> False
+        assertFalse(registry.isUserOnline("Ghost"));
+    }
+
+    // 4. Test Edge Cases (Null Safety) - Quan trọng để tránh NullPointerException
+    @Test
+    void testEdgeCases_NullInputs() {
+        // Set null -> Không được lỗi
+        assertDoesNotThrow(() -> registry.setTarget(null, "Alice"));
+        assertDoesNotThrow(() -> registry.setTarget("s1", null));
+
+        // Remove null -> Không được lỗi
+        assertDoesNotThrow(() -> registry.removeTarget(null));
+
+        // Get null -> Ra null
+        assertNull(registry.getTarget(null));
+
+        // Get targeting null -> Ra list rỗng (không được null)
+        List<String> result = registry.getSessionsTargeting(null);
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        // Check online null -> False
+        assertFalse(registry.isUserOnline(null));
+    }
+}

--- a/src/test/java/org/example/VChatTalk/util/SessionRegistryTest.java
+++ b/src/test/java/org/example/VChatTalk/util/SessionRegistryTest.java
@@ -13,86 +13,86 @@ class SessionRegistryTest {
 
     @BeforeEach
     void setUp() {
-        // Khởi tạo mới Registry trước mỗi bài test để dữ liệu sạch sẽ
+        // Initialize a clean registry before each test
         registry = new SessionRegistry();
     }
 
-    // 1. Test vòng đời cơ bản: Set -> Get -> Remove
+    // 1. Test basic lifecycle: Set -> Get -> Remove
     @Test
     void testTargetLifecycle() {
         String sessionId = "s1";
         String targetName = "Alice";
 
-        // Ban đầu chưa có gì
+        // Initially null
         assertNull(registry.getTarget(sessionId));
 
         // SET
         registry.setTarget(sessionId, targetName);
-        assertEquals(targetName, registry.getTarget(sessionId), "Sau khi set, get phải ra đúng tên");
+        assertEquals(targetName, registry.getTarget(sessionId), "Target name should match after setting");
 
         // REMOVE
         registry.removeTarget(sessionId);
-        assertNull(registry.getTarget(sessionId), "Sau khi remove, get phải ra null");
+        assertNull(registry.getTarget(sessionId), "Target should be null after removal");
     }
 
-    // 2. Test Reverse Lookup (Tìm ngược): Ai đang nhắm vào user này?
+    // 2. Test Reverse Lookup: Who is targeting this user?
     @Test
     void testGetSessionsTargeting() {
-        // Kịch bản: s1 và s2 cùng chat với Alice, s3 chat với Bob
+        // Scenario: s1 and s2 target Alice, s3 targets Bob
         registry.setTarget("s1", "Alice");
         registry.setTarget("s2", "Alice");
         registry.setTarget("s3", "Bob");
 
-        // Kiểm tra danh sách người đang chat với Alice
+        // Verify followers for Alice
         List<String> followersAlice = registry.getSessionsTargeting("Alice");
 
-        assertEquals(2, followersAlice.size(), "Phải có 2 người đang chat với Alice");
+        assertEquals(2, followersAlice.size(), "Alice should have 2 followers");
         assertTrue(followersAlice.contains("s1"));
         assertTrue(followersAlice.contains("s2"));
 
-        // Kiểm tra danh sách người đang chat với Bob
+        // Verify followers for Bob
         List<String> followersBob = registry.getSessionsTargeting("Bob");
         assertEquals(1, followersBob.size());
         assertTrue(followersBob.contains("s3"));
 
-        // Kiểm tra người không ai chat cùng
+        // Verify user with no followers
         List<String> followersNobody = registry.getSessionsTargeting("Charlie");
         assertTrue(followersNobody.isEmpty());
     }
 
-    // 3. Test check Online/Offline
+    // 3. Test Online/Offline check
     @Test
     void testIsUserOnline() {
         String sessionId = "s1";
         String username = "Alice";
 
-        // Ban đầu offline
+        // Initially offline
         assertFalse(registry.isUserOnline(username));
 
-        // Đăng ký user (Sử dụng hàm tryRegisterUser mà bạn vừa thêm)
+        // Register user
         registry.tryRegisterUser(sessionId, username);
 
-        // Bây giờ phải Online
+        // Should be online now
         assertTrue(registry.isUserOnline(username));
 
-        // Check tên lung tung -> False
+        // Check non-existent user -> False
         assertFalse(registry.isUserOnline("Ghost"));
     }
 
-    // 4. Test Edge Cases (Null Safety) - Quan trọng để tránh NullPointerException
+    // 4. Test Edge Cases (Null Safety) - prevent NullPointerException
     @Test
     void testEdgeCases_NullInputs() {
-        // Set null -> Không được lỗi
+        // Set null -> Should not throw exception
         assertDoesNotThrow(() -> registry.setTarget(null, "Alice"));
         assertDoesNotThrow(() -> registry.setTarget("s1", null));
 
-        // Remove null -> Không được lỗi
+        // Remove null -> Should not throw exception
         assertDoesNotThrow(() -> registry.removeTarget(null));
 
-        // Get null -> Ra null
+        // Get null -> Should return null
         assertNull(registry.getTarget(null));
 
-        // Get targeting null -> Ra list rỗng (không được null)
+        // Get targeting null -> Should return empty list (not null)
         List<String> result = registry.getSessionsTargeting(null);
         assertNotNull(result);
         assertTrue(result.isEmpty());


### PR DESCRIPTION
### Ticket: [CHAT-014A](https://vchattalk.atlassian.net/browse/SCRUM-78) (Maintain per-session private chat target)

**Overview:**
This PR implements the backend logic to maintain the "private chat target" context for each user session. It allows users to select a specific target for 1-on-1 messaging using the `/select` command. It also includes several critical bug fixes regarding session management and English localization.

**Key Changes:**

* **Session Management (`SessionRegistry`):**
    * Added `sessionTargets` (`ConcurrentHashMap`) to store `sessionId` -> `targetUsername` mapping.
    * Implemented `setTarget`, `getTarget`, `removeTarget` methods.
    * Implemented `getSessionsTargeting` to support reverse lookup (finding who is chatting with a specific user).
    * Fixed logic bug in `isUsernameOnline` (previously returned incorrect status).

* **Command Handling (`ChatWebSocketHandler`):**
    * Implemented `/select <username>`: Validates if the target exists/online. If valid, sets the session context and sends a System confirmation. If invalid, sends an Error.
    * Enhanced `/list`: Now displays the total count of online users.
    * **Disconnect Logic Update:** When a user disconnects, the system now notifies anyone currently targeting that user and clears their private chat context (AC3).
    * **Bug Fix (Silent Leave):** Reordered `afterConnectionClosed` logic to ensure "User Left" messages are generated before the session is removed.

* **Service Logic (`ChatService`):**
    * Added validation to prevent **Duplicate Usernames** during `/join`.
    * Standardized all system messages to **English**.