### PR TITLE
feat(chat): route non-command messages to selected private target

### DIFF
--- a/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
+++ b/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
@@ -150,6 +150,13 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
             }
 
             if (dto.getType() == MessageType.MESSAGE) {
+
+                if (!sessionRegistry.isUserRegistered(sessionId)) {
+                    log.warn("Anonymous user attempted to send a message: {}", dto.getContent());
+                    session.sendMessage(new TextMessage("You must join the chat before sending messages."));
+                    return;
+                }
+
                 chatService.routeMessage(session, dto);
             }
 

--- a/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
+++ b/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
@@ -149,8 +149,10 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                 }
             }
 
-            MessageDTO chat = chatService.handleMessage(sessionId, dto);
-            broadcast(chat, session);
+            if (dto.getType() == MessageType.MESSAGE) {
+                chatService.routeMessage(session, dto);
+            }
+
 
         } catch (IllegalArgumentException | IllegalStateException e) {
             sendError(session, e.getMessage());
@@ -234,7 +236,9 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                             + "/list - List all online users\n"
                             + "/select <name> - Select a user for private chat (1-on-1)\n"
                             + "/exit - Disconnect from the server.\n";
-                    session.sendMessage(new TextMessage("Available commands:\n" + commands));
+                    dto.setType(MessageType.SYSTEM);
+                    dto.setContent("Available commands:\n" + commands);
+                    session.sendMessage(new TextMessage(mapper.writeValueAsString(dto)));
                 }
 
                 case SELECT -> {

--- a/src/main/java/org/example/VChatTalk/service/ChatService.java
+++ b/src/main/java/org/example/VChatTalk/service/ChatService.java
@@ -5,6 +5,12 @@ import org.example.VChatTalk.model.MessageDTO;
 import org.example.VChatTalk.model.MessageType;
 import org.example.VChatTalk.util.SessionRegistry;
 import org.springframework.stereotype.Service;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.example.VChatTalk.util.AnsiColor;
+
+import java.io.IOException;
 
 import java.time.Instant;
 
@@ -15,7 +21,17 @@ public class ChatService {
     private final SessionRegistry sessionRegistry;
 
     public ChatService(SessionRegistry sessionRegistry) {
+
         this.sessionRegistry = sessionRegistry;
+    }
+
+    private MessageDTO cloneForPrivate(MessageDTO base, String content) {
+        MessageDTO dto = new MessageDTO();
+        dto.setType(base.getType());
+        dto.setSender(base.getSender());
+        dto.setTimestamp(base.getTimestamp());
+        dto.setContent(content);
+        return dto;
     }
 
     public MessageDTO handleJoin(String sessionId, MessageDTO dto) {
@@ -87,4 +103,60 @@ public class ChatService {
         if (input == null) return "";
         return input.replaceAll("[^a-zA-Z0-9_\\s-]", "").trim();
     }
+
+    public void routeMessage(WebSocketSession senderSession, MessageDTO dto) throws IOException {
+
+        String sessionId = senderSession.getId();
+
+        MessageDTO baseMessage = handleMessage(sessionId, dto);
+
+        String targetUsername = sessionRegistry.getTarget(sessionId);
+
+        if (targetUsername == null) {
+            sendSystem(senderSession,
+                    AnsiColor.YELLOW +
+                            "Use /select <username> to start a private chat." +
+                            AnsiColor.RESET
+            );
+            return;
+        }
+
+        WebSocketSession targetSession =
+                sessionRegistry.findSessionByUsername(targetUsername);
+
+        if (targetSession == null || !targetSession.isOpen()) {
+            sendSystem(senderSession,
+                    AnsiColor.RED + "User Offline" + AnsiColor.RESET
+            );
+            sessionRegistry.removeTarget(sessionId);
+            return;
+        }
+
+        MessageDTO toTarget = cloneForPrivate(baseMessage,
+                AnsiColor.GREEN + "[PM] " + baseMessage.getContent() + AnsiColor.RESET);
+
+        targetSession.sendMessage(new TextMessage(
+                new ObjectMapper().writeValueAsString(toTarget)
+        ));
+
+        MessageDTO selfEcho = cloneForPrivate(baseMessage,
+                AnsiColor.CYAN +
+                        "[You → " + targetUsername + "] " +
+                        baseMessage.getContent() +
+                        AnsiColor.RESET);
+
+        senderSession.sendMessage(new TextMessage(
+                new ObjectMapper().writeValueAsString(selfEcho)
+        ));
+    }
+    private void sendSystem(WebSocketSession session, String content) throws IOException {
+        MessageDTO dto = systemMessage(content);
+        session.sendMessage(
+                new TextMessage(
+                        new ObjectMapper().writeValueAsString(dto)
+                )
+        );
+    }
+
+
 }

--- a/src/main/java/org/example/VChatTalk/service/ChatService.java
+++ b/src/main/java/org/example/VChatTalk/service/ChatService.java
@@ -20,6 +20,8 @@ public class ChatService {
 
     private final SessionRegistry sessionRegistry;
 
+    private static final ObjectMapper mapper = new ObjectMapper();
+
     public ChatService(SessionRegistry sessionRegistry) {
 
         this.sessionRegistry = sessionRegistry;

--- a/src/main/java/org/example/VChatTalk/util/AnsiColor.java
+++ b/src/main/java/org/example/VChatTalk/util/AnsiColor.java
@@ -1,0 +1,12 @@
+package org.example.VChatTalk.util;
+
+public final class AnsiColor {
+    public static final String RESET = "\u001B[0m";
+    public static final String GREEN = "\u001B[32m";
+    public static final String CYAN = "\u001B[36m";
+    public static final String YELLOW = "\u001B[33m";
+    public static final String RED = "\u001B[31m";
+
+    private AnsiColor() {}
+}
+

--- a/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
@@ -107,12 +107,10 @@ public class SessionRegistry {
 
     // Check if user is online
     public boolean isUserOnline(String username) {
-        if (username == null) return false;
-
-        String sessionId = usernameSessions.get(username);
-        WebSocketSession session = sessions.get(sessionId);
-
-        return session != null && session.isOpen();
+        if (username == null) {
+            return false;
+        }
+        return usernameSessions.containsKey(username);
     }
 
 

--- a/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
@@ -18,6 +18,8 @@ public class SessionRegistry {
 
     private final ConcurrentHashMap<String, String> sessionUsernames = new ConcurrentHashMap<>();
 
+    private final ConcurrentHashMap<String, String> usernameSessions = new ConcurrentHashMap<>();
+
     // Map of private chat targets: key = sessionId (who is targeting), value = targetUsername (who is being targeted)
     private final ConcurrentHashMap<String, String> sessionTargets = new ConcurrentHashMap<>();
 
@@ -29,22 +31,31 @@ public class SessionRegistry {
     }
 
     public void removeSession(String sessionId) {
-        if(sessionId != null){
-            sessions.remove(sessionId);
-            sessionUsernames.remove(sessionId);
-        }
+        if (sessionId == null) return;
 
+        String username = sessionUsernames.remove(sessionId);
+        if (username != null) {
+            usernameSessions.remove(username);
+        }
+            sessionTargets.remove(sessionId);
+            sessions.remove(sessionId);
+
+            logger.info("Removed session {}", sessionId);
     }
     public String getUsername(String sessionId) {
         return sessionUsernames.getOrDefault(sessionId, "Anonymous");
     }
 
     public synchronized boolean tryRegisterUser(String sessionId, String username) {
-        if (sessionUsernames.containsValue(username)) {
+        if (sessionId == null || username == null || username.isBlank()) {
+            return false;
+        }
+        if (usernameSessions.containsKey(username)) {
             return false;
         }
 
         sessionUsernames.put(sessionId, username);
+        usernameSessions.put(username, sessionId);
 
         logger.info("Registered user: '{}' with session ID: {}", username, sessionId);
         return true;
@@ -56,13 +67,17 @@ public class SessionRegistry {
         }
         return sessions.get(sessionId);
     }
+    public WebSocketSession findSessionByUsername(String username) {
+        String sessionId = usernameSessions.get(username);
+        return sessionId != null ? sessions.get(sessionId) : null;
+    }
 
     public boolean isUserRegistered(String sessionId) {
         return sessionUsernames.containsKey(sessionId);
     }
 
     public Collection<WebSocketSession> getAllSessions(){
-        return sessions.values();
+        return Collections.unmodifiableCollection(sessions.values());
     }
     public void countSessions(){
         logger.info("Active sessions({})", sessions.size());
@@ -92,12 +107,14 @@ public class SessionRegistry {
 
     // Check if user is online
     public boolean isUserOnline(String username) {
-        if (username == null){
-            return false;
-        }
+        if (username == null) return false;
 
-        return sessionUsernames.containsValue(username);
+        String sessionId = usernameSessions.get(username);
+        WebSocketSession session = sessions.get(sessionId);
+
+        return session != null && session.isOpen();
     }
+
 
     // Find list of sessionIds targeting a single username
     public List<String> getSessionsTargeting(String targetUsername) {
@@ -115,6 +132,4 @@ public class SessionRegistry {
 
         return Collections.unmodifiableList(targetingSessions);
     }
-
-
 }

--- a/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
@@ -37,10 +37,10 @@ public class SessionRegistry {
         if (username != null) {
             usernameSessions.remove(username);
         }
-            sessionTargets.remove(sessionId);
-            sessions.remove(sessionId);
+        sessionTargets.remove(sessionId);
+        sessions.remove(sessionId);
 
-            logger.info("Removed session {}", sessionId);
+        logger.info("Removed session {}", sessionId);
     }
     public String getUsername(String sessionId) {
         return sessionUsernames.getOrDefault(sessionId, "Anonymous");
@@ -67,6 +67,16 @@ public class SessionRegistry {
         }
         return sessions.get(sessionId);
     }
+    /**
+     * Retrieves the {@link WebSocketSession} associated with the given username.
+     * <p>
+     * This method looks up the internal username-to-session mapping and returns
+     * the corresponding {@code WebSocketSession} if one is currently registered.
+     *
+     * @param username the username whose session should be retrieved; may be {@code null}
+     * @return the {@link WebSocketSession} associated with the given username,
+     *         or {@code null} if the username is not registered or if {@code username} is {@code null}
+     */
     public WebSocketSession findSessionByUsername(String username) {
         String sessionId = usernameSessions.get(username);
         return sessionId != null ? sessions.get(sessionId) : null;


### PR DESCRIPTION
Any input that does not start with the command prefix and has a valid targetUsername must be treated as a private message and routed only to that target’s session (FR-05, FR-06).​

If there is no valid target context, the server should not silently drop the message; it should respond with a yellow system hint or follow the agreed fallback behavior.​

Private messages to the receiver are formatted in green (FR-07), and the sender’s own view uses cyan.​

If the target becomes offline between messages, routing must fail gracefully with a red “User Offline” error.​