### PR TITLE
SCRUM-84 RF-5.1: Create IChatCommand Interface & CommandExecutor Service

### DIFF
--- a/src/main/java/org/example/VChatTalk/command/CommandExecutor.java
+++ b/src/main/java/org/example/VChatTalk/command/CommandExecutor.java
@@ -1,0 +1,26 @@
+package org.example.VChatTalk.command;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+public class CommandExecutor {
+    private final Map<CommandType, IChatCommand> commandRegistry;
+
+    public CommandExecutor(List<IChatCommand> commands) {
+        this.commandRegistry = commands.stream().collect(Collectors.toMap(IChatCommand::getType, Function.identity()));
+    }
+    public void execute(WebSocketSession session, CommandResult result)throws IOException{
+        commandRegistry.getOrDefault(result.getType(),commandRegistry.get(CommandType.UNKNOWN)).execute(session,result);
+    }
+    public IChatCommand getCommand(CommandType type){
+        return commandRegistry.get(type);
+    }
+}

--- a/src/main/java/org/example/VChatTalk/command/IChatCommand.java
+++ b/src/main/java/org/example/VChatTalk/command/IChatCommand.java
@@ -1,0 +1,10 @@
+package org.example.VChatTalk.command;
+
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+public interface IChatCommand {
+    CommandType getType();
+    void execute(WebSocketSession session, CommandResult result) throws IOException;
+}


### PR DESCRIPTION
- Create a new ChatCommand Interface to handle preexisting command as well as future commands that replace the need for if/switch case function.
- Create a new CommandExecutor to handle the execution of command given the command type based off ChatCommand Interface.