### PR TITLE
SCRUM-88 RF-5.4: Fix SessionRegistry Concurrency

### DIFF
--- a/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
@@ -50,14 +50,17 @@ public class SessionRegistry {
         if (sessionId == null || username == null || username.isBlank()) {
             return false;
         }
-        String existingSession =
-                usernameSessions.putIfAbsent(username, sessionId);
 
+        String existingSession = usernameSessions.putIfAbsent(username, sessionId);
         if (existingSession != null) {
             return false;
         }
 
-        sessionUsernames.put(sessionId, username);
+        String previousUsername = sessionUsernames.putIfAbsent(sessionId, username);
+        if (previousUsername != null) {
+            usernameSessions.remove(username, sessionId);
+            return false;
+        }
 
         logger.info("Registered user: '{}' with session ID: {}", username, sessionId);
         return true;

--- a/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
@@ -46,16 +46,18 @@ public class SessionRegistry {
         return sessionUsernames.getOrDefault(sessionId, "Anonymous");
     }
 
-    public synchronized boolean tryRegisterUser(String sessionId, String username) {
+    public boolean tryRegisterUser(String sessionId, String username) {
         if (sessionId == null || username == null || username.isBlank()) {
             return false;
         }
-        if (usernameSessions.containsKey(username)) {
+        String existingSession =
+                usernameSessions.putIfAbsent(username, sessionId);
+
+        if (existingSession != null) {
             return false;
         }
 
         sessionUsernames.put(sessionId, username);
-        usernameSessions.put(username, sessionId);
 
         logger.info("Registered user: '{}' with session ID: {}", username, sessionId);
         return true;

--- a/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
@@ -50,12 +50,12 @@ public class SessionRegistry {
         if (sessionId == null || username == null || username.isBlank()) {
             return false;
         }
-
+        // Step 1: Reserve username atomically
         String existingSession = usernameSessions.putIfAbsent(username, sessionId);
         if (existingSession != null) {
             return false;
         }
-
+        // Step 2: Bind sessionId -> username
         String previousUsername = sessionUsernames.putIfAbsent(sessionId, username);
         if (previousUsername != null) {
             usernameSessions.remove(username, sessionId);


### PR DESCRIPTION
Description: 

Critical performance fix: Remove all `synchronized` keyword usage from SessionRegistry methods. Replace with ConcurrentHashMap atomic operations (putIfAbsent, remove, computeIfPresent). Current design causes 100 concurrent user registrations to process sequentially - major performance violation of NFR-01 (2000+ concurrent users). After fix: true concurrent registration with no global object locking.

 
Acceptance Criteria: 

[ ] Remove ALL `synchronized` keywords from all public and private methods in SessionRegistry

[ ] Replace all `Map` field declarations with `ConcurrentHashMap` for concurrent collections

[ ] Replace `Map<String, Session> sessions` with `ConcurrentHashMap<String, Session>`

[ ] Replace `Map<String, String> sessionUsernames` with `ConcurrentHashMap<String, String>`

[ ] Replace `Map<String, String> usernameSessions` with `ConcurrentHashMap<String, String>`

[ ] Replace `Map<String, String> sessionTargets` with `ConcurrentHashMap<String, String>`

[ ] Method `tryRegisterUser()` uses atomic `putIfAbsent()` instead of synchronized block

[ ] Method `setTarget()` uses atomic operations for state update

[ ] Method `removeTarget()` uses atomic operations for state removal

[ ] All read operations (getUsername, isUserOnline, findSessionById, etc.) are lock-free

[ ] No explicit synchronized blocks remain anywhere in class

[ ] Thread-safety maintained via ConcurrentHashMap atomic semantics

[ ] Concurrency test: 100 concurrent user registrations complete within 100ms

[ ] Stress test: 1000 concurrent mixed operations without deadlock or race conditions

[ ] Unit tests: 100% coverage including concurrency scenarios

[ ] Code review approved

[ ] Code compiles without errors