### PR TITLE
SCRUM-89 RF-5.5: Create User Session

### DIFF
--- a/src/main/java/org/example/VChatTalk/model/UserSession.java
+++ b/src/main/java/org/example/VChatTalk/model/UserSession.java
@@ -2,13 +2,12 @@ package org.example.VChatTalk.model;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.With;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.util.Objects;
 
-@Setter
+
 @Getter
 @Builder
 public class UserSession {
@@ -26,7 +25,8 @@ public class UserSession {
     public boolean equals(Object o) {
         if(this == o) return true;
         if(!(o instanceof UserSession)) return false;
-        return Objects.equals(this.sessionId, ((UserSession) o).sessionId);    }
+        return Objects.equals(this.sessionId, ((UserSession) o).sessionId); // fixed it
+    }
 
     @Override
     public int hashCode() {

--- a/src/main/java/org/example/VChatTalk/model/UserSession.java
+++ b/src/main/java/org/example/VChatTalk/model/UserSession.java
@@ -1,0 +1,36 @@
+package org.example.VChatTalk.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.With;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.Objects;
+
+@Setter
+@Getter
+@Builder
+public class UserSession {
+    private final String sessionId;
+    @With
+    private final String username;        // null nếu chưa đăng ký
+    @With
+    private final String targetUser;      // chat riêng
+    private final WebSocketSession session;
+    @With
+    private final String currentRoomId;   // cho Sprint 6
+
+    // equals & hashCode dựa trên sessionId
+    @Override
+    public boolean equals(Object o) {
+        if(this == o) return true;
+        if(!(o instanceof UserSession)) return false;
+        return sessionId.equals(((UserSession) o).sessionId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sessionId);
+    }
+}

--- a/src/main/java/org/example/VChatTalk/model/UserSession.java
+++ b/src/main/java/org/example/VChatTalk/model/UserSession.java
@@ -14,20 +14,19 @@ import java.util.Objects;
 public class UserSession {
     private final String sessionId;
     @With
-    private final String username;        // null nếu chưa đăng ký
+    private final String username;
     @With
-    private final String targetUser;      // chat riêng
+    private final String targetUser;
     private final WebSocketSession session;
     @With
-    private final String currentRoomId;   // cho Sprint 6
+    private final String currentRoomId;
 
-    // equals & hashCode dựa trên sessionId
+
     @Override
     public boolean equals(Object o) {
         if(this == o) return true;
         if(!(o instanceof UserSession)) return false;
-        return sessionId.equals(((UserSession) o).sessionId);
-    }
+        return Objects.equals(this.sessionId, ((UserSession) o).sessionId);    }
 
     @Override
     public int hashCode() {

--- a/src/main/java/org/example/VChatTalk/util/PrivateChatRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/PrivateChatRegistry.java
@@ -1,0 +1,45 @@
+package org.example.VChatTalk.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class PrivateChatRegistry {
+
+    // key = sessionId (who is targeting), value = targetUsername (who is being targeted)
+    private final ConcurrentHashMap<String, String> sessionTargets = new ConcurrentHashMap<>();
+
+    public void setTarget(String sessionId, String targetUsername) {
+        if (sessionId != null && targetUsername != null) {
+            sessionTargets.put(sessionId, targetUsername);
+        }
+    }
+
+    public String getTarget(String sessionId) {
+        if (sessionId == null) return null;
+        return sessionTargets.get(sessionId);
+    }
+
+    public void removeTarget(String sessionId) {
+        if (sessionId != null) {
+            sessionTargets.remove(sessionId);
+        }
+    }
+
+    public List<String> getSessionsTargeting(String targetUsername) {
+        if (targetUsername == null) return Collections.emptyList();
+
+        List<String> targetingSessions = new ArrayList<>();
+        sessionTargets.forEach((sessionId, target) -> {
+            if (target.equals(targetUsername)) {
+                targetingSessions.add(sessionId);
+            }
+        });
+
+        return Collections.unmodifiableList(targetingSessions);
+    }
+}

--- a/src/main/java/org/example/VChatTalk/util/UserRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/UserRegistry.java
@@ -1,0 +1,56 @@
+package org.example.VChatTalk.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class UserRegistry {
+    private static final Logger logger = LoggerFactory.getLogger(UserRegistry.class);
+
+    private final ConcurrentHashMap<String, String> sessionUsernames = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, String> usernameSessions = new ConcurrentHashMap<>();
+
+    public boolean tryRegisterUser(String sessionId, String username) {
+        if (sessionId == null || username == null || username.isBlank()) return false;
+
+        String existingSession = usernameSessions.putIfAbsent(username, sessionId);
+        if (existingSession != null) return false;
+
+        String previousUsername = sessionUsernames.putIfAbsent(sessionId, username);
+        if (previousUsername != null) {
+            usernameSessions.remove(username, sessionId);
+            return false;
+        }
+
+        logger.info("Registered user: '{}' with session ID: {}", username, sessionId);
+        return true;
+    }
+
+    public void removeUser(String sessionId) {
+        if (sessionId == null) return;
+        String username = sessionUsernames.remove(sessionId);
+        if (username != null) {
+            usernameSessions.remove(username);
+        }
+    }
+
+    public String getUsername(String sessionId) {
+        return sessionUsernames.getOrDefault(sessionId, "Anonymous");
+    }
+
+    public boolean isUserRegistered(String sessionId) {
+        return sessionUsernames.containsKey(sessionId);
+    }
+
+    public boolean isUserOnline(String username) {
+        if (username == null) return false;
+        return usernameSessions.containsKey(username);
+    }
+
+    public String getSessionId(String username) {
+        return usernameSessions.get(username);
+    }
+}


### PR DESCRIPTION
# Refactor User and Private Chat Management Registries

## Summary

This PR refactors the user and private chat management logic in the VChatTalk project, without modifying the existing `SessionRegistry` logic. The goal is to follow **SOLID principles** and improve code maintainability and clarity.

Specifically, this PR introduces:

- `UserSession` - an immutable model representing a WebSocket session tied to a username.
- `UserRegistry` - responsible solely for managing the mapping between usernames and session IDs.
- `PrivateChatRegistry` - responsible solely for managing private chat targets for each session.

The `SessionRegistry` remains unchanged in terms of logic and functionality. Its role continues to be **managing WebSocketSession instances** only. Any user-related logic previously mixed into it has been extracted into the new registries. This ensures each class now has a **single responsibility**, making future extensions (e.g., room management, chat groups) easier to implement without introducing duplication or complexity.

## Motivation

- The original `SessionRegistry` handled multiple concerns:
  1. Managing WebSocket sessions.
  2. Tracking registered users.
  3. Tracking private chat targets.

  Mixing these responsibilities makes the code harder to maintain and violates the **Single Responsibility Principle (SRP)**.

- By extracting user and private chat logic:
  - `UserRegistry` is now the single source of truth for session ID ↔ username mapping.
  - `PrivateChatRegistry` is now the single source of truth for session targets.
  - `UserSession` provides a clean, immutable representation of a user’s session with proper equality/hashCode semantics.

- This approach reduces duplication, increases readability, and makes it easier to reason about state changes (e.g., user registration, chat target changes) without touching session management.

## Implementation Details

- **UserSession**
  - Immutable class with `sessionId`, `username`, and `WebSocketSession`.
  - Overrides `equals` and `hashCode` based on `sessionId` to allow proper use in sets/maps.

- **UserRegistry**
  - Stores `sessionId` ↔ `username` mappings.
  - Handles registration, removal, and user online checks.
  - Decouples user state from session management.

- **PrivateChatRegistry**
  - Stores session ↔ targetUsername mappings.
  - Provides methods to set/get/remove chat targets and query sessions targeting a specific user.
  - Fully decoupled from session and user management.

- **SessionRegistry**
  - No functional changes were made.
  - Continues to manage WebSocketSession instances.
  - Acts solely as a registry of active sessions.

## Benefits

- **SRP Compliance**: Each class now has a single responsibility.
- **Code Clarity**: Easier to read and maintain, with no duplication of mappings or logic.
- **Future-Proofing**: Makes it easier to extend chat or room-related features without impacting core session logic.
- **Thread Safety**: Uses `ConcurrentHashMap` consistently in all registries.
- **Immutable Model**: `UserSession` ensures stable identity for each session.

## Notes

- This PR is a **structural refactor only**.
- No changes were made to actual session behavior or chat functionality.
- All existing logic for registration, lookup, and private chat targets remains unchanged.
