### PR TITLE
fix(RF-5.3): apply SRP to WebSocketHandler and adding global chat back

### DIFF
--- a/src/main/java/org/example/VChatTalk/command/MessageConstants.java
+++ b/src/main/java/org/example/VChatTalk/command/MessageConstants.java
@@ -39,7 +39,7 @@ public class MessageConstants {
 
     public static final String ERR_RATE_LIMIT = AnsiColor.RED + "You are sending messages too quickly. Please slow down." + AnsiColor.RESET;
 
-    public static final String ERR_SEND_MUST_LOGIN = AnsiColor.RED + "You must join the chat before sending messages. Use /login <name>" + AnsiColor.RESET;
+    public static final String ERR_SEND_MUST_LOGIN = AnsiColor.RED + "You must login before before sending messages. Use /login <name>" + AnsiColor.RESET;
 
     public static final String ERR_INVALID_JSON = AnsiColor.RED + "Invalid message format." + AnsiColor.RESET;
 

--- a/src/main/java/org/example/VChatTalk/dummy_client_test/DummyClientTest.java
+++ b/src/main/java/org/example/VChatTalk/dummy_client_test/DummyClientTest.java
@@ -12,6 +12,10 @@ import java.time.Instant;
 import java.util.Scanner;
 import java.util.concurrent.CompletionStage;
 
+/**
+ * Simple CLI WebSocket client for VChat-Talk testing
+ * All logic is handled by server
+ */
 public class DummyClientTest {
 
     private static WebSocket webSocket;
@@ -22,13 +26,12 @@ public class DummyClientTest {
 
     public static void main(String[] args) {
 
-        System.out.println("=== Dummy CLI Chat Client (CHAT-013) ===");
-        System.out.println("Commands:");
-        System.out.println("  /help");
-        System.out.println("  /join <username>");
-        System.out.println("  /send <message>");
-        System.out.println("  /exit");
-        System.out.println("--------------------------------------");
+        System.out.println("=== VChat-Talk CLI Client ===");
+        System.out.println("Getting started:");
+        System.out.println("  1. /login <username> - Login to chat");
+        System.out.println("  2. /help            - Show all available commands");
+        System.out.println("  3. /exit            - Exit client");
+        System.out.println("----------------------------------------------------");
 
         try {
             HttpClient client = HttpClient.newHttpClient();
@@ -52,8 +55,11 @@ public class DummyClientTest {
                             }
                     ).join();
 
+            System.out.println("Connected to server");
+
         } catch (Exception e) {
             System.out.println("ERROR: Failed to connect to ws://localhost:8080/chat");
+            System.out.println("Make sure the server is running!");
             return;
         }
 
@@ -63,75 +69,40 @@ public class DummyClientTest {
         while (true) {
             String input = scanner.nextLine().trim();
 
-            if (input.startsWith("/join ")) {
-                handleJoin(input);
-            } else if (input.startsWith("/send ")) {
-                handleSend(input);
-            } else if (input.equals("/exit")) {
-                handleExit();
-                break;
-            } else if (input.startsWith("/")) {
-                sendMessage(
-                        MessageDTO.builder()
-                                .type(MessageType.MESSAGE)
-                                .sender(username != null ? username : "unknown")
-                                .content(input)
-                                .timestamp(Instant.now())
-                                .build()
-                );
-            } else {
-                System.out.println("ERROR: Unknown command");
+            if (input.isEmpty()) {
+                System.out.print("> ");
+                continue;
             }
 
-            System.out.print("> ");
+            // Local exit command only
+            if (input.equals("/exit")) {
+                handleExit();
+                break;
+            }
+
+            // Handle /join locally to track username
+            if (input.startsWith("/join ")) {
+                String[] parts = input.split("\\s+", 2);
+                if (parts.length >= 2) {
+                    username = parts[1];
+                }
+            }
+
+            // Send everything to server (including /join)
+            sendMessage(
+                    MessageDTO.builder()
+                            .type(input.startsWith("/join") ? MessageType.JOIN : MessageType.MESSAGE)
+                            .sender(username != null ? username : "Guest")
+                            .content(input.startsWith("/join") ? null : input)
+                            .timestamp(Instant.now())
+                            .build()
+            );
         }
 
         scanner.close();
     }
 
-    // ===================== COMMAND HANDLERS =====================
-
-    private static void handleJoin(String input) {
-        String[] parts = input.split("\\s+", 2);
-
-        if (parts.length < 2 || parts[1].isBlank()) {
-            System.out.println("ERROR: Username cannot be empty");
-            return;
-        }
-
-        username = parts[1];
-
-        sendMessage(
-                MessageDTO.builder()
-                        .type(MessageType.JOIN)
-                        .sender(username)
-                        .timestamp(Instant.now())
-                        .build()
-        );
-    }
-
-    private static void handleSend(String input) {
-        if (username == null) {
-            System.out.println("ERROR: You must /join first");
-            return;
-        }
-
-        String[] parts = input.split("\\s+", 2);
-
-        if (parts.length < 2 || parts[1].isBlank()) {
-            System.out.println("ERROR: Message cannot be empty");
-            return;
-        }
-
-        sendMessage(
-                MessageDTO.builder()
-                        .type(MessageType.MESSAGE)
-                        .sender(username)
-                        .content(parts[1])
-                        .timestamp(Instant.now())
-                        .build()
-        );
-    }
+    // ===================== EXIT COMMAND =====================
 
     private static void handleExit() {
         if (username != null) {
@@ -144,38 +115,46 @@ public class DummyClientTest {
             );
         }
 
-        webSocket.sendClose(
-                WebSocket.NORMAL_CLOSURE,
-                "Client exit"
-        );
-
-        System.out.println("INFO: Exit chat");
+        webSocket.sendClose(WebSocket.NORMAL_CLOSURE, "Client exit");
+        System.out.println("Goodbye!");
     }
 
-    // ===================== JSON SEND =====================
+    // ===================== SEND/RECEIVE =====================
 
     private static void sendMessage(MessageDTO message) {
         try {
             String json = mapper.writeValueAsString(message);
             webSocket.sendText(json, true);
         } catch (Exception e) {
-            System.out.println("ERROR: Failed to serialize message");
+            System.out.println("ERROR: Failed to send message");
         }
     }
-
-    // ===================== DISPLAY =====================
 
     private static void printIncomingMessage(String json) {
         try {
             MessageDTO message = mapper.readValue(json, MessageDTO.class);
 
-            System.out.printf(
-                    "Sender: %s | Type: %s | Content: %s | Time: %s%n",
-                    message.getSender(),
-                    message.getType(),
-                    message.getContent(),
-                    message.getTimestamp()
-            );
+            System.out.println(); // New line
+
+            String content = message.getContent() != null ? message.getContent() : "";
+
+            // Simple display based on message type
+            switch (message.getType()) {
+                case SYSTEM:
+                    System.out.println("[SYSTEM] " + content);
+                    break;
+
+                case ERROR:
+                    System.out.println("[ERROR] " + content);
+                    break;
+
+                case MESSAGE:
+                    System.out.println(message.getSender() + ": " + content);
+                    break;
+
+                default:
+                    System.out.println(message.getSender() + ": " + content);
+            }
 
         } catch (Exception e) {
             System.out.println("[RAW] " + json);

--- a/src/main/java/org/example/VChatTalk/dummy_client_test/DummyClientTest.java
+++ b/src/main/java/org/example/VChatTalk/dummy_client_test/DummyClientTest.java
@@ -25,12 +25,13 @@ public class DummyClientTest {
             .registerModule(new JavaTimeModule());
 
     public static void main(String[] args) {
-
         System.out.println("=== VChat-Talk CLI Client ===");
         System.out.println("Getting started:");
-        System.out.println("  1. /login <username> - Login to chat");
-        System.out.println("  2. /help            - Show all available commands");
-        System.out.println("  3. /exit            - Exit client");
+        System.out.println("  1. /login <username>  - Login to connect to the chat");
+        System.out.println("  2. /join <room>       - Join room. Need login first");
+        System.out.println("  3. /select <username> - Private chat. Need login first");
+        System.out.println("  4. /help              - Show all available commands");
+        System.out.println("  5. /exit              - Exit client");
         System.out.println("----------------------------------------------------");
 
         try {
@@ -81,7 +82,7 @@ public class DummyClientTest {
             }
 
             // Handle /join locally to track username
-            if (input.startsWith("/join ")) {
+            if (input.startsWith("/login ")) {
                 String[] parts = input.split("\\s+", 2);
                 if (parts.length >= 2) {
                     username = parts[1];
@@ -91,9 +92,9 @@ public class DummyClientTest {
             // Send everything to server (including /join)
             sendMessage(
                     MessageDTO.builder()
-                            .type(input.startsWith("/join") ? MessageType.JOIN : MessageType.MESSAGE)
+                            .type(input.startsWith("/login") ? MessageType.JOIN : MessageType.MESSAGE)
                             .sender(username != null ? username : "Guest")
-                            .content(input.startsWith("/join") ? null : input)
+                            .content(input.startsWith("/login") ? null : input)
                             .timestamp(Instant.now())
                             .build()
             );
@@ -134,7 +135,7 @@ public class DummyClientTest {
         try {
             MessageDTO message = mapper.readValue(json, MessageDTO.class);
 
-            System.out.println(); // New line
+            System.out.println();
 
             String content = message.getContent() != null ? message.getContent() : "";
 

--- a/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
+++ b/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
@@ -63,7 +63,6 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         }
 
         // Clean up all registries
-        privateChatRegistry.removeTarget(sessionId);
         rateLimiter.removeSession(sessionId);
         sessionRegistry.removeSession(sessionId);
 

--- a/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
+++ b/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
@@ -1,213 +1,126 @@
 package org.example.VChatTalk.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.VChatTalk.command.CommandExecutor;
 import org.example.VChatTalk.command.MessageConstants;
-import org.example.VChatTalk.command.service.CommandParserService;
-import org.example.VChatTalk.command.CommandResult;
-import org.example.VChatTalk.command.CommandType;
-import org.example.VChatTalk.service.ChatService;
-import org.example.VChatTalk.util.SessionRegistry;
 import org.example.VChatTalk.model.MessageDTO;
-import org.example.VChatTalk.model.MessageType;
-import org.example.VChatTalk.util.SystemResponseSender;
+import org.example.VChatTalk.service.BroadcastService;
+import org.example.VChatTalk.service.ChatService;
+import org.example.VChatTalk.service.MessageProcessor;
+import org.example.VChatTalk.util.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
-import java.io.IOException;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
+/**
+ * WebSocket handler for chat functionality
+ * Manages connection lifecycle and delegates message processing
+ */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class ChatWebSocketHandler extends TextWebSocketHandler {
 
-    private final SystemResponseSender systemResponseSender;
     private final SessionRegistry sessionRegistry;
-    private final CommandParserService commandParserService;
-    private static final long RATE_LIMIT_MS = 200;
-
-    private static final ConcurrentHashMap<String, Long> lastMessageTime = new ConcurrentHashMap<>();
-    private static final Set<WebSocketSession> sessions = ConcurrentHashMap.newKeySet();
+    private final UserRegistry userRegistry;
+    private final PrivateChatRegistry privateChatRegistry;
     private final ChatService chatService;
-    private final ObjectMapper mapper;
-    private final CommandExecutor commandExecutor;
-
-    public ChatWebSocketHandler(SessionRegistry sessionRegistry, ChatService chatService,
-                                CommandParserService commandParserService, ObjectMapper mapper,
-                                CommandExecutor commandExecutor, SystemResponseSender systemResponseSender) {
-        this.sessionRegistry = sessionRegistry;
-        this.chatService = chatService;
-        this.commandParserService = commandParserService;
-        this.mapper = mapper;
-        this.commandExecutor = commandExecutor;
-        this.systemResponseSender = systemResponseSender;
-    }
-
+    private final MessageProcessor messageProcessor;
+    private final BroadcastService broadcastService;
+    private final RateLimiter rateLimiter;
+    private final SystemResponseSender systemResponseSender;
 
     /**
-     * ========== CONNECTION HANDLING ==========
+     * ========== CONNECTION LIFECYCLE ==========
+     */
+
+    /**
+     * Called when new WebSocket connection is established
      */
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         sessionRegistry.addSession(session);
-        sessions.add(session);
-
         systemResponseSender.sendSystem(session, MessageConstants.MSG_WELCOME);
 
-        log.info("[CONNECT] New session: {}", session.getId());
+        log.info("[CONNECT] Session: {}", session.getId());
         sessionRegistry.countSessions();
     }
 
+    /**
+     * Called when WebSocket connection is closed
+     * Cleans up all session data and notifies affected users
+     */
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
-
         String sessionId = session.getId();
-        String username = sessionRegistry.getUsername(sessionId);
+        String username = userRegistry.getUsername(sessionId);
 
+        // Notify followers if user was registered (not Anonymous)
         if (!MessageConstants.USER_ANONYMOUS.equals(username)) {
-            List<String> followers = sessionRegistry.getSessionsTargeting(username);
-
-            for (String followerSessionId : followers) {
-                WebSocketSession followerSession = sessionRegistry.findSessionById(followerSessionId);
-                // Check if online
-                if (followerSession != null && followerSession.isOpen()) {
-                    try {
-                        // Remove target and reset to global or null
-                        sessionRegistry.removeTarget(followerSessionId);
-
-                        systemResponseSender.sendSystem(
-                                followerSession,
-                                String.format(
-                                        MessageConstants.MSG_DISCONNECT_NOTIFY,
-                                        username
-                                )
-                        );
-                    } catch (IOException e) {
-                        log.error("Error sending disconnect notification: {}", e.getMessage());
-                    }
-                }
-            }
+            notifyFollowersOfDisconnect(username);
         }
 
-        sessionRegistry.removeTarget(sessionId);
+        // Clean up all registries
+        privateChatRegistry.removeTarget(sessionId);
+        rateLimiter.removeSession(sessionId);
+        sessionRegistry.removeSession(sessionId);
 
+        // Handle leave and broadcast to all users
         MessageDTO leaveMessage = chatService.handleLeave(sessionId);
-
-        sessions.remove(session);
-        lastMessageTime.remove(sessionId);
-
         if (leaveMessage != null) {
-            broadcast(leaveMessage, null);
+            broadcastService.broadcast(leaveMessage, null);
         }
 
-        log.info("[DISCONNECT] {} - {}", sessionId, status.getCode());
+        log.info("[DISCONNECT] {} - Status: {}", sessionId, status.getCode());
         sessionRegistry.countSessions();
     }
 
     /**
      * ========== MESSAGE HANDLING ==========
      */
+
+    /**
+     * Called when text message is received from WebSocket
+     */
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
-        long now = System.currentTimeMillis();
-        Long last = lastMessageTime.get(session.getId());
-
-        // rate limit check
-        if (last != null && now - last < RATE_LIMIT_MS) {
+        // Rate limit check - prevent spam
+        if (rateLimiter.isRateLimitExceeded(session.getId())) {
             systemResponseSender.sendError(session, MessageConstants.ERR_RATE_LIMIT);
             return;
         }
-        lastMessageTime.put(session.getId(), now);
 
-        String payload = message.getPayload();
-        log.info("[RECEIVE] {} -> {}", session.getId(), payload);
-
-        String sessionId = session.getId();
-        try {
-            MessageDTO dto = mapper.readValue(payload, MessageDTO.class);
-            if (dto.getType() == MessageType.JOIN) {
-                MessageDTO system = chatService.handleJoin(sessionId, dto);
-                broadcast(system, null);
-                systemResponseSender.sendSystem(session, MessageConstants.MSG_JOINED_SUCCESS);
-                return;
-            }
-
-            if (dto.getType() == MessageType.MESSAGE && dto.getContent() != null && dto.getContent().startsWith("/")){
-                if (!sessionRegistry.isUserRegistered(session.getId())) {
-                    log.warn("Anonymous user attempted to execute a command: {}", dto.getContent());
-                    // Optionally, send a message back to the user saying they must register first
-                    session.sendMessage(new TextMessage("You must join the chat before executing commands."));
-                    return;
-                }
-                CommandResult result = commandParserService.parse(dto.getContent());
-
-                if (result.getType() != CommandType.NONE) {
-                    commandExecutor.execute(session, result);
-                    return;
-                }
-            }
-
-            if (dto.getType() == MessageType.MESSAGE) {
-
-                if (!sessionRegistry.isUserRegistered(sessionId)) {
-                    log.warn("Anonymous user attempted to send a message: {}", dto.getContent());
-                    session.sendMessage(new TextMessage(MessageConstants.ERR_SEND_MUST_LOGIN));
-                    return;
-                }
-
-                chatService.routeMessage(session, dto);
-            }
-
-
-        } catch (IllegalArgumentException | IllegalStateException e) {
-            systemResponseSender.sendError(session, e.getMessage());
-
-        } catch (Exception e) {
-            log.warn("[PARSE_ERROR] From [{}]: {}", sessionId, e.getMessage());
-            systemResponseSender.sendError(session, MessageConstants.ERR_INVALID_JSON);
-        }
-
+        // Delegate message processing to MessageProcessor
+        messageProcessor.processMessage(session, message.getPayload());
     }
 
     /**
-     * ========== BROADCAST ==========
+     * ========== HELPER METHODS ==========
      */
-    private void broadcast(MessageDTO dto, WebSocketSession sender) {
-        try {
-            String json = mapper.writeValueAsString(dto);
-            Iterator<WebSocketSession> iterator = sessions.iterator();
-            boolean isSystemMessage = (sender == null);
 
-            while (iterator.hasNext()) {
-                WebSocketSession s = iterator.next();
+    /**
+     * Notify all users who were targeting the disconnected user
+     * Remove their targets and send notification
+     */
+    private void notifyFollowersOfDisconnect(String username) {
+        privateChatRegistry.getSessionsTargeting(username).forEach(followerSessionId -> {
+            WebSocketSession followerSession = sessionRegistry.findSessionById(followerSessionId);
+
+            if (followerSession != null && followerSession.isOpen()) {
                 try {
-                    if (s.isOpen() && (isSystemMessage || !s.getId().equals(sender.getId()))) {
-                        s.sendMessage(new TextMessage(json));
-                    } else if (!s.isOpen()) {
-                        cleanup(iterator, s);
-                    }
-                } catch (IOException e) {
-                    cleanup(iterator, s);
+                    // Remove target and return to global mode
+                    privateChatRegistry.removeTarget(followerSessionId);
+
+                    systemResponseSender.sendSystem(
+                            followerSession,
+                            String.format(MessageConstants.MSG_DISCONNECT_NOTIFY, username)
+                    );
+                } catch (Exception e) {
+                    log.error("Error notifying follower {}: {}", followerSessionId, e.getMessage());
                 }
             }
-
-            log.info("[BROADCAST] [{}] -> {} clients", dto.getSender(), sessions.size() - 1);
-        } catch (IOException e) {
-            log.error("[BROADCAST_ERROR] {}", e.getMessage());
-        }
-    }
-
-    private void cleanup(Iterator<WebSocketSession> iterator, WebSocketSession s) {
-        iterator.remove();
-        sessionRegistry.removeSession(s.getId());
-        lastMessageTime.remove(s.getId());
-        log.warn("[CLEANUP] Removed dead session {}", s.getId());
+        });
     }
 }

--- a/src/main/java/org/example/VChatTalk/service/BroadcastService.java
+++ b/src/main/java/org/example/VChatTalk/service/BroadcastService.java
@@ -1,0 +1,70 @@
+package org.example.VChatTalk.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.VChatTalk.model.MessageDTO;
+import org.example.VChatTalk.util.SessionRegistry;
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * Service for broadcasting messages to WebSocket sessions
+ * Handles both global broadcasts and direct session messages
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BroadcastService {
+
+    private final ObjectMapper mapper;
+    private final SessionRegistry sessionRegistry;
+
+    /**
+     * Broadcast message to all connected sessions except sender
+     * @param dto Message to broadcast
+     * @param sender Sender session (null for system messages)
+     */
+    public void broadcast(MessageDTO dto, WebSocketSession sender) {
+        try {
+            String json = mapper.writeValueAsString(dto);
+            Collection<WebSocketSession> sessions = sessionRegistry.getAllSessions();
+            boolean isSystemMessage = (sender == null);
+
+            int successCount = 0;
+            for (WebSocketSession session : sessions) {
+                try {
+                    // Send to all (if system message) or all except sender
+                    if (session.isOpen() && (isSystemMessage || !session.getId().equals(sender.getId()))) {
+                        session.sendMessage(new TextMessage(json));
+                        successCount++;
+                    }
+                } catch (IOException e) {
+                    log.warn("[BROADCAST_FAILED] Session: {} - {}", session.getId(), e.getMessage());
+                    // Session cleanup handled by afterConnectionClosed in handler
+                }
+            }
+
+            log.info("[BROADCAST] Sender: [{}] -> {} clients", dto.getSender(), successCount);
+        } catch (IOException e) {
+            log.error("[BROADCAST_ERROR] Failed to serialize message: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Send message to specific session only
+     * @param session Target session
+     * @param dto Message to send
+     * @throws IOException if sending fails
+     */
+    public void sendToSession(WebSocketSession session, MessageDTO dto) throws IOException {
+        if (session != null && session.isOpen()) {
+            String json = mapper.writeValueAsString(dto);
+            session.sendMessage(new TextMessage(json));
+        }
+    }
+}

--- a/src/main/java/org/example/VChatTalk/service/ChatService.java
+++ b/src/main/java/org/example/VChatTalk/service/ChatService.java
@@ -1,197 +1,197 @@
-package org.example.VChatTalk.service;
+    package org.example.VChatTalk.service;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.example.VChatTalk.model.MessageDTO;
-import org.example.VChatTalk.model.MessageType;
-import org.example.VChatTalk.util.AnsiColor;
-import org.example.VChatTalk.util.PrivateChatRegistry;
-import org.example.VChatTalk.util.SessionRegistry;
-import org.example.VChatTalk.util.UserRegistry;
-import org.springframework.stereotype.Service;
-import org.springframework.web.socket.WebSocketSession;
+    import lombok.RequiredArgsConstructor;
+    import lombok.extern.slf4j.Slf4j;
+    import org.example.VChatTalk.model.MessageDTO;
+    import org.example.VChatTalk.model.MessageType;
+    import org.example.VChatTalk.util.AnsiColor;
+    import org.example.VChatTalk.util.PrivateChatRegistry;
+    import org.example.VChatTalk.util.SessionRegistry;
+    import org.example.VChatTalk.util.UserRegistry;
+    import org.springframework.stereotype.Service;
+    import org.springframework.web.socket.WebSocketSession;
 
-import java.io.IOException;
-import java.time.Instant;
-
-/**
- * Core chat business logic service
- * Handles user join/leave, message processing, and routing
- */
-@Slf4j
-@Service
-@RequiredArgsConstructor
-public class ChatService {
-
-    private final SessionRegistry sessionRegistry;
-    private final UserRegistry userRegistry;
-    private final PrivateChatRegistry privateChatRegistry;
-    private final BroadcastService broadcastService;
-
-    // ========== MESSAGE ROUTING ==========
+    import java.io.IOException;
+    import java.time.Instant;
 
     /**
-     * Route message to either global chat or private chat based on user's target
+     * Core chat business logic service
+     * Handles user join/leave, message processing, and routing
      */
-    public void routeMessage(WebSocketSession senderSession, MessageDTO dto) throws IOException {
-        String sessionId = senderSession.getId();
-        MessageDTO baseMessage = handleMessage(sessionId, dto);
+    @Slf4j
+    @Service
+    @RequiredArgsConstructor
+    public class ChatService {
 
-        String targetUsername = privateChatRegistry.getTarget(sessionId);
+        private final SessionRegistry sessionRegistry;
+        private final UserRegistry userRegistry;
+        private final PrivateChatRegistry privateChatRegistry;
+        private final BroadcastService broadcastService;
 
-        if (targetUsername != null) {
-            // PRIVATE CHAT MODE
-            handlePrivateMessage(senderSession, baseMessage, targetUsername);
-        } else {
-            // GLOBAL CHAT MODE - broadcast to all
-            broadcastService.broadcast(baseMessage, senderSession);
+        // ========== MESSAGE ROUTING ==========
+
+        /**
+         * Route message to either global chat or private chat based on user's target
+         */
+        public void routeMessage(WebSocketSession senderSession, MessageDTO dto) throws IOException {
+            String sessionId = senderSession.getId();
+            MessageDTO baseMessage = handleMessage(sessionId, dto);
+
+            String targetUsername = privateChatRegistry.getTarget(sessionId);
+
+            if (targetUsername != null) {
+                // PRIVATE CHAT MODE
+                handlePrivateMessage(senderSession, baseMessage, targetUsername);
+            } else {
+                // GLOBAL CHAT MODE - broadcast to all
+                broadcastService.broadcast(baseMessage, senderSession);
+            }
+        }
+
+        // ========== JOIN/LEAVE HANDLERS ==========
+
+        /**
+         * Handle user join request
+         * Validates username and registers user
+         */
+        public MessageDTO handleJoin(String sessionId, MessageDTO dto) {
+            if (userRegistry.isUserRegistered(sessionId)) {
+                throw new IllegalStateException("You have already joined the chat.");
+            }
+
+            if (dto.getContent() != null && !dto.getContent().isBlank()) {
+                throw new IllegalArgumentException("JOIN message must not contain content.");
+            }
+
+            String name = sanitize(dto.getSender());
+            if (name.isBlank()) {
+                throw new IllegalArgumentException("Username is required. Please login with a username.");
+            }
+
+            if (name.length() > 20) {
+                throw new IllegalArgumentException("Username is too long (max 20 characters).");
+            }
+
+            boolean success = userRegistry.tryRegisterUser(sessionId, name);
+            if (!success) {
+                throw new IllegalArgumentException("Username '" + name + "' is already taken. Please choose another.");
+            }
+
+            int count = userRegistry.countOnlineUsers();
+            return systemMessage(name + " has joined the chat. (Total: " + count + ")");
+        }
+
+        /**
+         * Handle user leave/disconnect
+         * Cleans up user registration and private chat target
+         */
+        public MessageDTO handleLeave(String sessionId) {
+            if (!userRegistry.isUserRegistered(sessionId)) {
+                return null;
+            }
+
+            String username = userRegistry.getUsername(sessionId);
+            userRegistry.removeUser(sessionId);
+            privateChatRegistry.removeTarget(sessionId);
+
+            int count = userRegistry.countOnlineUsers();
+            return systemMessage(username + " has left the chat. (Total: " + count + ")");
+        }
+
+        // ========== MESSAGE PROCESSING ==========
+
+        /**
+         * Process and validate regular chat message
+         * Sets sender username and timestamp
+         */
+        public MessageDTO handleMessage(String sessionId, MessageDTO dto) {
+            if (!userRegistry.isUserRegistered(sessionId)) {
+                throw new IllegalStateException("Please login before chatting.");
+            }
+
+            if (dto.getContent() == null || dto.getContent().isBlank()) {
+                throw new IllegalArgumentException("Empty message ignored.");
+            }
+
+            dto.setSender(userRegistry.getUsername(sessionId));
+            dto.setType(MessageType.MESSAGE);
+            dto.setTimestamp(Instant.now());
+            return dto;
+        }
+
+        // ========== PRIVATE METHODS ==========
+
+        /**
+         * Handle private message routing
+         * Validates target user and sends message to both sender and receiver
+         */
+        private void handlePrivateMessage(WebSocketSession sender, MessageDTO message, String targetUsername)
+                throws IOException {
+
+            // Find target session using UserRegistry
+            String targetSessionId = userRegistry.getSessionId(targetUsername);
+            if (targetSessionId == null) {
+                sendUserOfflineMessage(sender, targetUsername);
+                return;
+            }
+
+            WebSocketSession targetSession = sessionRegistry.findSessionById(targetSessionId);
+            if (targetSession == null || !targetSession.isOpen()) {
+                sendUserOfflineMessage(sender, targetUsername);
+                return;
+            }
+
+            // Send PM to target with [PM] prefix
+            MessageDTO toTarget = MessageDTO.builder()
+                    .type(message.getType())
+                    .sender(message.getSender())
+                    .timestamp(message.getTimestamp())
+                    .content(AnsiColor.GREEN + "[PM] " + message.getContent() + AnsiColor.RESET)
+                    .build();
+            broadcastService.sendToSession(targetSession, toTarget);
+
+            // Echo to sender with [You → target] prefix
+            MessageDTO selfEcho = MessageDTO.builder()
+                    .type(message.getType())
+                    .sender(message.getSender())
+                    .timestamp(message.getTimestamp())
+                    .content(AnsiColor.CYAN + "[You → " + targetUsername + "] " +
+                            message.getContent() + AnsiColor.RESET)
+                    .build();
+            broadcastService.sendToSession(sender, selfEcho);
+
+            log.info("[PRIVATE_MSG] {} → {}: {}", message.getSender(), targetUsername, message.getContent());
+        }
+
+        /**
+         * Send "user offline" notification and remove target
+         */
+        private void sendUserOfflineMessage(WebSocketSession session, String targetUsername) throws IOException {
+            MessageDTO offlineMsg = systemMessage(
+                    AnsiColor.RED + "User '" + targetUsername + "' is offline. " +
+                            "Returning to global chat." + AnsiColor.RESET
+            );
+            broadcastService.sendToSession(session, offlineMsg);
+            privateChatRegistry.removeTarget(session.getId());
+        }
+
+        /**
+         * Create system message DTO
+         */
+        private MessageDTO systemMessage(String content) {
+            return MessageDTO.builder()
+                    .type(MessageType.SYSTEM)
+                    .sender("System")
+                    .content(content)
+                    .timestamp(Instant.now())
+                    .build();
+        }
+
+        /**
+         * Sanitize username input - remove special characters
+         */
+        private String sanitize(String input) {
+            if (input == null) return "";
+            return input.replaceAll("[^a-zA-Z0-9_\\s-]", "").trim();
         }
     }
-
-    // ========== JOIN/LEAVE HANDLERS ==========
-
-    /**
-     * Handle user join request
-     * Validates username and registers user
-     */
-    public MessageDTO handleJoin(String sessionId, MessageDTO dto) {
-        if (userRegistry.isUserRegistered(sessionId)) {
-            throw new IllegalStateException("You have already joined the chat.");
-        }
-
-        if (dto.getContent() != null && !dto.getContent().isBlank()) {
-            throw new IllegalArgumentException("JOIN message must not contain content.");
-        }
-
-        String name = sanitize(dto.getSender());
-        if (name.isBlank()) {
-            name = "Guest_" + sessionId.substring(0, 8);
-        }
-
-        if (name.length() > 20) {
-            throw new IllegalArgumentException("Username is too long (max 20 characters).");
-        }
-
-        boolean success = userRegistry.tryRegisterUser(sessionId, name);
-        if (!success) {
-            throw new IllegalArgumentException("Username '" + name + "' is already taken. Please choose another.");
-        }
-
-        int count = userRegistry.countOnlineUsers();
-        return systemMessage(name + " has joined the chat. (Total: " + count + ")");
-    }
-
-    /**
-     * Handle user leave/disconnect
-     * Cleans up user registration and private chat target
-     */
-    public MessageDTO handleLeave(String sessionId) {
-        if (!userRegistry.isUserRegistered(sessionId)) {
-            return null;
-        }
-
-        String username = userRegistry.getUsername(sessionId);
-        userRegistry.removeUser(sessionId);
-        privateChatRegistry.removeTarget(sessionId);
-
-        int count = userRegistry.countOnlineUsers();
-        return systemMessage(username + " has left the chat. (Total: " + count + ")");
-    }
-
-    // ========== MESSAGE PROCESSING ==========
-
-    /**
-     * Process and validate regular chat message
-     * Sets sender username and timestamp
-     */
-    public MessageDTO handleMessage(String sessionId, MessageDTO dto) {
-        if (!userRegistry.isUserRegistered(sessionId)) {
-            throw new IllegalStateException("Please send a JOIN message before chatting.");
-        }
-
-        if (dto.getContent() == null || dto.getContent().isBlank()) {
-            throw new IllegalArgumentException("Empty message ignored.");
-        }
-
-        dto.setSender(userRegistry.getUsername(sessionId));
-        dto.setType(MessageType.MESSAGE);
-        dto.setTimestamp(Instant.now());
-        return dto;
-    }
-
-    // ========== PRIVATE METHODS ==========
-
-    /**
-     * Handle private message routing
-     * Validates target user and sends message to both sender and receiver
-     */
-    private void handlePrivateMessage(WebSocketSession sender, MessageDTO message, String targetUsername)
-            throws IOException {
-
-        // Find target session using UserRegistry
-        String targetSessionId = userRegistry.getSessionId(targetUsername);
-        if (targetSessionId == null) {
-            sendUserOfflineMessage(sender, targetUsername);
-            return;
-        }
-
-        WebSocketSession targetSession = sessionRegistry.findSessionById(targetSessionId);
-        if (targetSession == null || !targetSession.isOpen()) {
-            sendUserOfflineMessage(sender, targetUsername);
-            return;
-        }
-
-        // Send PM to target with [PM] prefix
-        MessageDTO toTarget = MessageDTO.builder()
-                .type(message.getType())
-                .sender(message.getSender())
-                .timestamp(message.getTimestamp())
-                .content(AnsiColor.GREEN + "[PM] " + message.getContent() + AnsiColor.RESET)
-                .build();
-        broadcastService.sendToSession(targetSession, toTarget);
-
-        // Echo to sender with [You → target] prefix
-        MessageDTO selfEcho = MessageDTO.builder()
-                .type(message.getType())
-                .sender(message.getSender())
-                .timestamp(message.getTimestamp())
-                .content(AnsiColor.CYAN + "[You → " + targetUsername + "] " +
-                        message.getContent() + AnsiColor.RESET)
-                .build();
-        broadcastService.sendToSession(sender, selfEcho);
-
-        log.info("[PRIVATE_MSG] {} → {}: {}", message.getSender(), targetUsername, message.getContent());
-    }
-
-    /**
-     * Send "user offline" notification and remove target
-     */
-    private void sendUserOfflineMessage(WebSocketSession session, String targetUsername) throws IOException {
-        MessageDTO offlineMsg = systemMessage(
-                AnsiColor.RED + "User '" + targetUsername + "' is offline. " +
-                        "Returning to global chat." + AnsiColor.RESET
-        );
-        broadcastService.sendToSession(session, offlineMsg);
-        privateChatRegistry.removeTarget(session.getId());
-    }
-
-    /**
-     * Create system message DTO
-     */
-    private MessageDTO systemMessage(String content) {
-        return MessageDTO.builder()
-                .type(MessageType.SYSTEM)
-                .sender("System")
-                .content(content)
-                .timestamp(Instant.now())
-                .build();
-    }
-
-    /**
-     * Sanitize username input - remove special characters
-     */
-    private String sanitize(String input) {
-        if (input == null) return "";
-        return input.replaceAll("[^a-zA-Z0-9_\\s-]", "").trim();
-    }
-}

--- a/src/main/java/org/example/VChatTalk/service/ChatService.java
+++ b/src/main/java/org/example/VChatTalk/service/ChatService.java
@@ -1,45 +1,61 @@
 package org.example.VChatTalk.service;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.VChatTalk.model.MessageDTO;
 import org.example.VChatTalk.model.MessageType;
-import org.example.VChatTalk.util.SessionRegistry;
-import org.springframework.stereotype.Service;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.web.socket.TextMessage;
-import org.springframework.web.socket.WebSocketSession;
 import org.example.VChatTalk.util.AnsiColor;
+import org.example.VChatTalk.util.PrivateChatRegistry;
+import org.example.VChatTalk.util.SessionRegistry;
+import org.example.VChatTalk.util.UserRegistry;
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
-
 import java.time.Instant;
 
+/**
+ * Core chat business logic service
+ * Handles user join/leave, message processing, and routing
+ */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class ChatService {
 
     private final SessionRegistry sessionRegistry;
+    private final UserRegistry userRegistry;
+    private final PrivateChatRegistry privateChatRegistry;
+    private final BroadcastService broadcastService;
 
-    private final ObjectMapper mapper;
+    // ========== MESSAGE ROUTING ==========
 
-    public ChatService(SessionRegistry sessionRegistry, ObjectMapper mapper) {
+    /**
+     * Route message to either global chat or private chat based on user's target
+     */
+    public void routeMessage(WebSocketSession senderSession, MessageDTO dto) throws IOException {
+        String sessionId = senderSession.getId();
+        MessageDTO baseMessage = handleMessage(sessionId, dto);
 
-        this.sessionRegistry = sessionRegistry;
-        this.mapper = mapper;
+        String targetUsername = privateChatRegistry.getTarget(sessionId);
+
+        if (targetUsername != null) {
+            // PRIVATE CHAT MODE
+            handlePrivateMessage(senderSession, baseMessage, targetUsername);
+        } else {
+            // GLOBAL CHAT MODE - broadcast to all
+            broadcastService.broadcast(baseMessage, senderSession);
+        }
     }
 
-    private MessageDTO cloneForPrivate(MessageDTO base, String content) {
-        MessageDTO dto = new MessageDTO();
-        dto.setType(base.getType());
-        dto.setSender(base.getSender());
-        dto.setTimestamp(base.getTimestamp());
-        dto.setContent(content);
-        return dto;
-    }
+    // ========== JOIN/LEAVE HANDLERS ==========
 
+    /**
+     * Handle user join request
+     * Validates username and registers user
+     */
     public MessageDTO handleJoin(String sessionId, MessageDTO dto) {
-
-        if (sessionRegistry.isUserRegistered(sessionId)) {
+        if (userRegistry.isUserRegistered(sessionId)) {
             throw new IllegalStateException("You have already joined the chat.");
         }
 
@@ -56,19 +72,40 @@ public class ChatService {
             throw new IllegalArgumentException("Username is too long (max 20 characters).");
         }
 
-        boolean success = sessionRegistry.tryRegisterUser(sessionId, name);
+        boolean success = userRegistry.tryRegisterUser(sessionId, name);
         if (!success) {
             throw new IllegalArgumentException("Username '" + name + "' is already taken. Please choose another.");
         }
 
-
-        int count = sessionRegistry.getAllSessions().size();
+        int count = userRegistry.countOnlineUsers();
         return systemMessage(name + " has joined the chat. (Total: " + count + ")");
     }
 
-    public MessageDTO handleMessage(String sessionId, MessageDTO dto) {
+    /**
+     * Handle user leave/disconnect
+     * Cleans up user registration and private chat target
+     */
+    public MessageDTO handleLeave(String sessionId) {
+        if (!userRegistry.isUserRegistered(sessionId)) {
+            return null;
+        }
 
-        if (!sessionRegistry.isUserRegistered(sessionId)) {
+        String username = userRegistry.getUsername(sessionId);
+        userRegistry.removeUser(sessionId);
+        privateChatRegistry.removeTarget(sessionId);
+
+        int count = userRegistry.countOnlineUsers();
+        return systemMessage(username + " has left the chat. (Total: " + count + ")");
+    }
+
+    // ========== MESSAGE PROCESSING ==========
+
+    /**
+     * Process and validate regular chat message
+     * Sets sender username and timestamp
+     */
+    public MessageDTO handleMessage(String sessionId, MessageDTO dto) {
+        if (!userRegistry.isUserRegistered(sessionId)) {
             throw new IllegalStateException("Please send a JOIN message before chatting.");
         }
 
@@ -76,90 +113,85 @@ public class ChatService {
             throw new IllegalArgumentException("Empty message ignored.");
         }
 
-        dto.setSender(sessionRegistry.getUsername(sessionId));
+        dto.setSender(userRegistry.getUsername(sessionId));
         dto.setType(MessageType.MESSAGE);
         dto.setTimestamp(Instant.now());
         return dto;
     }
 
-    public MessageDTO handleLeave(String sessionId) {
-        if (!sessionRegistry.isUserRegistered(sessionId)) {
-            return null;
+    // ========== PRIVATE METHODS ==========
+
+    /**
+     * Handle private message routing
+     * Validates target user and sends message to both sender and receiver
+     */
+    private void handlePrivateMessage(WebSocketSession sender, MessageDTO message, String targetUsername)
+            throws IOException {
+
+        // Find target session using UserRegistry
+        String targetSessionId = userRegistry.getSessionId(targetUsername);
+        if (targetSessionId == null) {
+            sendUserOfflineMessage(sender, targetUsername);
+            return;
         }
 
-        String username = sessionRegistry.getUsername(sessionId);
-        sessionRegistry.removeSession(sessionId);
-        int count = sessionRegistry.getAllSessions().size();
-        return systemMessage(username + " has left the chat. (Total: " + count + ")");
+        WebSocketSession targetSession = sessionRegistry.findSessionById(targetSessionId);
+        if (targetSession == null || !targetSession.isOpen()) {
+            sendUserOfflineMessage(sender, targetUsername);
+            return;
+        }
+
+        // Send PM to target with [PM] prefix
+        MessageDTO toTarget = MessageDTO.builder()
+                .type(message.getType())
+                .sender(message.getSender())
+                .timestamp(message.getTimestamp())
+                .content(AnsiColor.GREEN + "[PM] " + message.getContent() + AnsiColor.RESET)
+                .build();
+        broadcastService.sendToSession(targetSession, toTarget);
+
+        // Echo to sender with [You → target] prefix
+        MessageDTO selfEcho = MessageDTO.builder()
+                .type(message.getType())
+                .sender(message.getSender())
+                .timestamp(message.getTimestamp())
+                .content(AnsiColor.CYAN + "[You → " + targetUsername + "] " +
+                        message.getContent() + AnsiColor.RESET)
+                .build();
+        broadcastService.sendToSession(sender, selfEcho);
+
+        log.info("[PRIVATE_MSG] {} → {}: {}", message.getSender(), targetUsername, message.getContent());
     }
 
+    /**
+     * Send "user offline" notification and remove target
+     */
+    private void sendUserOfflineMessage(WebSocketSession session, String targetUsername) throws IOException {
+        MessageDTO offlineMsg = systemMessage(
+                AnsiColor.RED + "User '" + targetUsername + "' is offline. " +
+                        "Returning to global chat." + AnsiColor.RESET
+        );
+        broadcastService.sendToSession(session, offlineMsg);
+        privateChatRegistry.removeTarget(session.getId());
+    }
+
+    /**
+     * Create system message DTO
+     */
     private MessageDTO systemMessage(String content) {
-        MessageDTO dto = new MessageDTO();
-        dto.setType(MessageType.SYSTEM);
-        dto.setSender("System");
-        dto.setContent(content);
-        dto.setTimestamp(Instant.now());
-        return dto;
+        return MessageDTO.builder()
+                .type(MessageType.SYSTEM)
+                .sender("System")
+                .content(content)
+                .timestamp(Instant.now())
+                .build();
     }
 
+    /**
+     * Sanitize username input - remove special characters
+     */
     private String sanitize(String input) {
         if (input == null) return "";
         return input.replaceAll("[^a-zA-Z0-9_\\s-]", "").trim();
     }
-
-    public void routeMessage(WebSocketSession senderSession, MessageDTO dto) throws IOException {
-
-        String sessionId = senderSession.getId();
-
-        MessageDTO baseMessage = handleMessage(sessionId, dto);
-
-        String targetUsername = sessionRegistry.getTarget(sessionId);
-
-        if (targetUsername == null) {
-            sendSystem(senderSession,
-                    AnsiColor.YELLOW +
-                            "Use /select <username> to start a private chat." +
-                            AnsiColor.RESET
-            );
-            return;
-        }
-
-        WebSocketSession targetSession =
-                sessionRegistry.findSessionByUsername(targetUsername);
-
-        if (targetSession == null || !targetSession.isOpen()) {
-            sendSystem(senderSession,
-                    AnsiColor.RED + "User Offline" + AnsiColor.RESET
-            );
-            sessionRegistry.removeTarget(sessionId);
-            return;
-        }
-
-        MessageDTO toTarget = cloneForPrivate(baseMessage,
-                AnsiColor.GREEN + "[PM] " + baseMessage.getContent() + AnsiColor.RESET);
-
-        targetSession.sendMessage(new TextMessage(
-                mapper.writeValueAsString(toTarget)
-        ));
-
-        MessageDTO selfEcho = cloneForPrivate(baseMessage,
-                AnsiColor.CYAN +
-                        "[You → " + targetUsername + "] " +
-                        baseMessage.getContent() +
-                        AnsiColor.RESET);
-
-        senderSession.sendMessage(new TextMessage(
-                mapper.writeValueAsString(selfEcho)
-        ));
-    }
-    private void sendSystem(WebSocketSession session, String content) throws IOException {
-        MessageDTO dto = systemMessage(content);
-        session.sendMessage(
-                new TextMessage(
-                        mapper.writeValueAsString(dto)
-                )
-        );
-    }
-
-
 }

--- a/src/main/java/org/example/VChatTalk/service/MessageProcessor.java
+++ b/src/main/java/org/example/VChatTalk/service/MessageProcessor.java
@@ -1,0 +1,155 @@
+package org.example.VChatTalk.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.VChatTalk.command.CommandExecutor;
+import org.example.VChatTalk.command.CommandResult;
+import org.example.VChatTalk.command.CommandType;
+import org.example.VChatTalk.command.MessageConstants;
+import org.example.VChatTalk.command.service.CommandParserService;
+import org.example.VChatTalk.model.MessageDTO;
+import org.example.VChatTalk.model.MessageType;
+import org.example.VChatTalk.util.SystemResponseSender;
+import org.example.VChatTalk.util.UserRegistry;
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+/**
+ * Processes incoming WebSocket messages
+ * Handles message parsing, validation, and routing to appropriate handlers
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MessageProcessor {
+
+    private final ObjectMapper mapper;
+    private final UserRegistry userRegistry;
+    private final ChatService chatService;
+    private final CommandParserService commandParserService;
+    private final CommandExecutor commandExecutor;
+    private final SystemResponseSender systemResponseSender;
+    private final BroadcastService broadcastService;
+
+    /**
+     * Process incoming WebSocket text message
+     * @param session WebSocket session
+     * @param payload Raw message payload
+     * @return true if message was handled successfully
+     */
+    public boolean processMessage(WebSocketSession session, String payload) {
+        String sessionId = session.getId();
+        log.info("[RECEIVE] {} -> {}", sessionId, payload);
+
+        try {
+            MessageDTO dto = mapper.readValue(payload, MessageDTO.class);
+
+            // Handle JOIN message
+            if (dto.getType() == MessageType.JOIN) {
+                return handleJoinMessage(session, sessionId, dto);
+            }
+
+            // Handle COMMAND message (starts with /)
+            if (dto.getType() == MessageType.MESSAGE && isCommand(dto.getContent())) {
+                return handleCommandMessage(session, dto);
+            }
+
+            // Handle regular CHAT message
+            if (dto.getType() == MessageType.MESSAGE) {
+                return handleChatMessage(session, sessionId, dto);
+            }
+
+            return true;
+
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            try {
+                systemResponseSender.sendError(session, e.getMessage());
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+            return false;
+
+        } catch (Exception e) {
+            log.warn("[PARSE_ERROR] From [{}]: {}", sessionId, e.getMessage());
+            try {
+                systemResponseSender.sendError(session, MessageConstants.ERR_INVALID_JSON);
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Handle JOIN message - user registration
+     */
+    private boolean handleJoinMessage(WebSocketSession session, String sessionId, MessageDTO dto) {
+        MessageDTO systemMessage = chatService.handleJoin(sessionId, dto);
+        broadcastService.broadcast(systemMessage, null);
+        try {
+            systemResponseSender.sendSystem(session, MessageConstants.MSG_JOINED_SUCCESS);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return true;
+    }
+
+    /**
+     * Handle COMMAND message (e.g., /select, /leave, /list)
+     */
+    private boolean handleCommandMessage(WebSocketSession session, MessageDTO dto) throws IOException {
+
+        CommandResult result = commandParserService.parse(dto.getContent());
+
+        if (result.getType() == CommandType.NONE) {
+            return false;
+        }
+
+        boolean isPublicCommand =
+                result.getType() == CommandType.LOGIN
+                        || result.getType() == CommandType.HELP;
+
+        if (!isPublicCommand && !userRegistry.isUserRegistered(session.getId())) {
+            log.warn("Anonymous user attempted protected command: {}", dto.getContent());
+            session.sendMessage(new TextMessage(MessageConstants.ERR_SEND_MUST_LOGIN));
+            return false;
+        }
+
+        commandExecutor.execute(session, result);
+        return true;
+    }
+
+    /**
+     * Handle regular CHAT message
+     */
+    private boolean handleChatMessage(WebSocketSession session, String sessionId, MessageDTO dto) {
+        if (!userRegistry.isUserRegistered(sessionId)) {
+            log.warn("Anonymous user attempted to send message: {}", dto.getContent());
+            try {
+                session.sendMessage(new TextMessage(MessageConstants.ERR_SEND_MUST_LOGIN));
+            } catch (IOException e) {
+                log.error("Failed to send error message", e);
+            }
+            return false;
+        }
+
+        try {
+            chatService.routeMessage(session, dto);
+            return true;
+        } catch (IOException e) {
+            log.error("Failed to route message", e);
+            return false;
+        }
+    }
+
+    /**
+     * Check if message content is a command
+     */
+    private boolean isCommand(String content) {
+        return content != null && content.startsWith("/");
+    }
+}

--- a/src/main/java/org/example/VChatTalk/service/MessageProcessor.java
+++ b/src/main/java/org/example/VChatTalk/service/MessageProcessor.java
@@ -13,7 +13,6 @@ import org.example.VChatTalk.model.MessageType;
 import org.example.VChatTalk.util.SystemResponseSender;
 import org.example.VChatTalk.util.UserRegistry;
 import org.springframework.stereotype.Service;
-import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
@@ -48,38 +47,24 @@ public class MessageProcessor {
         try {
             MessageDTO dto = mapper.readValue(payload, MessageDTO.class);
 
-            // Handle JOIN message
             if (dto.getType() == MessageType.JOIN) {
                 return handleJoinMessage(session, sessionId, dto);
             }
-
-            // Handle COMMAND message (starts with /)
             if (dto.getType() == MessageType.MESSAGE && isCommand(dto.getContent())) {
                 return handleCommandMessage(session, dto);
             }
-
-            // Handle regular CHAT message
             if (dto.getType() == MessageType.MESSAGE) {
                 return handleChatMessage(session, sessionId, dto);
             }
-
             return true;
 
         } catch (IllegalArgumentException | IllegalStateException e) {
-            try {
-                systemResponseSender.sendError(session, e.getMessage());
-            } catch (IOException ex) {
-                throw new RuntimeException(ex);
-            }
+            // FIX: Don't throw RuntimeException, just log and notify user
+            sendErrorSafe(session, e.getMessage());
             return false;
-
         } catch (Exception e) {
             log.warn("[PARSE_ERROR] From [{}]: {}", sessionId, e.getMessage());
-            try {
-                systemResponseSender.sendError(session, MessageConstants.ERR_INVALID_JSON);
-            } catch (IOException ex) {
-                throw new RuntimeException(ex);
-            }
+            sendErrorSafe(session, MessageConstants.ERR_INVALID_JSON);
             return false;
         }
     }
@@ -88,34 +73,31 @@ public class MessageProcessor {
      * Handle JOIN message - user registration
      */
     private boolean handleJoinMessage(WebSocketSession session, String sessionId, MessageDTO dto) {
-        MessageDTO systemMessage = chatService.handleJoin(sessionId, dto);
-        broadcastService.broadcast(systemMessage, null);
         try {
+            MessageDTO systemMessage = chatService.handleJoin(sessionId, dto);
+            broadcastService.broadcast(systemMessage, null);
             systemResponseSender.sendSystem(session, MessageConstants.MSG_JOINED_SUCCESS);
+            return true;
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            log.error("Failed to send JOIN response", e);
+            return false;
         }
-        return true;
     }
 
     /**
      * Handle COMMAND message (e.g., /select, /leave, /list)
      */
     private boolean handleCommandMessage(WebSocketSession session, MessageDTO dto) throws IOException {
-
         CommandResult result = commandParserService.parse(dto.getContent());
 
-        if (result.getType() == CommandType.NONE) {
-            return false;
-        }
+        if (result.getType() == CommandType.NONE) return false;
 
-        boolean isPublicCommand =
-                result.getType() == CommandType.LOGIN
-                        || result.getType() == CommandType.HELP;
+        boolean isPublicCommand = result.getType() == CommandType.LOGIN || result.getType() == CommandType.HELP;
 
         if (!isPublicCommand && !userRegistry.isUserRegistered(session.getId())) {
             log.warn("Anonymous user attempted protected command: {}", dto.getContent());
-            session.sendMessage(new TextMessage(MessageConstants.ERR_SEND_MUST_LOGIN));
+            // FIX: Use standardized sender instead of raw session.sendMessage
+            sendErrorSafe(session, MessageConstants.ERR_SEND_MUST_LOGIN);
             return false;
         }
 
@@ -129,11 +111,7 @@ public class MessageProcessor {
     private boolean handleChatMessage(WebSocketSession session, String sessionId, MessageDTO dto) {
         if (!userRegistry.isUserRegistered(sessionId)) {
             log.warn("Anonymous user attempted to send message: {}", dto.getContent());
-            try {
-                session.sendMessage(new TextMessage(MessageConstants.ERR_SEND_MUST_LOGIN));
-            } catch (IOException e) {
-                log.error("Failed to send error message", e);
-            }
+            sendErrorSafe(session, MessageConstants.ERR_SEND_MUST_LOGIN);
             return false;
         }
 
@@ -143,6 +121,15 @@ public class MessageProcessor {
         } catch (IOException e) {
             log.error("Failed to route message", e);
             return false;
+        }
+    }
+
+    // Helper to safely send errors without polluting logic with try-catch blocks
+    private void sendErrorSafe(WebSocketSession session, String message) {
+        try {
+            systemResponseSender.sendError(session, message);
+        } catch (IOException e) {
+            log.debug("Failed to send error message to session {}: {}", session.getId(), e.getMessage());
         }
     }
 

--- a/src/main/java/org/example/VChatTalk/util/RateLimiter.java
+++ b/src/main/java/org/example/VChatTalk/util/RateLimiter.java
@@ -1,0 +1,48 @@
+package org.example.VChatTalk.util;
+
+import org.springframework.stereotype.Component;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Rate limiter to prevent message spam
+ * Tracks last message timestamp per session
+ */
+@Component
+public class RateLimiter {
+
+    private static final long RATE_LIMIT_MS = 200L;
+    private final ConcurrentHashMap<String, Long> lastMessageTime = new ConcurrentHashMap<>();
+
+    /**
+     * Check if session has exceeded rate limit
+     * @param sessionId WebSocket session ID
+     * @return true if rate limit exceeded, false otherwise
+     */
+    public boolean isRateLimitExceeded(String sessionId) {
+        long now = System.currentTimeMillis();
+        Long last = lastMessageTime.get(sessionId);
+
+        if (last != null && now - last < RATE_LIMIT_MS) {
+            return true;
+        }
+
+        lastMessageTime.put(sessionId, now);
+        return false;
+    }
+
+    /**
+     * Remove session from rate limiter when disconnected
+     */
+    public void removeSession(String sessionId) {
+        if (sessionId != null) {
+            lastMessageTime.remove(sessionId);
+        }
+    }
+
+    /**
+     * Clear all rate limit data (for testing/maintenance)
+     */
+    public void clear() {
+        lastMessageTime.clear();
+    }
+}

--- a/src/main/java/org/example/VChatTalk/util/RateLimiter.java
+++ b/src/main/java/org/example/VChatTalk/util/RateLimiter.java
@@ -20,14 +20,19 @@ public class RateLimiter {
      */
     public boolean isRateLimitExceeded(String sessionId) {
         long now = System.currentTimeMillis();
-        Long last = lastMessageTime.get(sessionId);
 
-        if (last != null && now - last < RATE_LIMIT_MS) {
-            return true;
-        }
+        boolean[] isSpam = {false};
 
-        lastMessageTime.put(sessionId, now);
-        return false;
+        // Atomic check-and-update
+        Long result = lastMessageTime.compute(sessionId, (key, last) -> {
+            if (last != null && (now - last < RATE_LIMIT_MS)) {
+                isSpam[0] = true;
+                return last; // Keep old time
+            }
+                return now;
+        });
+        // If the map value is NOT 'now', it means we kept the old value -> Spam detected
+        return isSpam[0];
     }
 
     /**
@@ -38,7 +43,6 @@ public class RateLimiter {
             lastMessageTime.remove(sessionId);
         }
     }
-
     /**
      * Clear all rate limit data (for testing/maintenance)
      */

--- a/src/test/java/org/example/VChatTalk/handler/ChatWebSocketHandlerTest.java
+++ b/src/test/java/org/example/VChatTalk/handler/ChatWebSocketHandlerTest.java
@@ -1,221 +1,114 @@
 package org.example.VChatTalk.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.example.VChatTalk.command.CommandExecutor;
-import org.example.VChatTalk.command.service.CommandParserService;
-import org.example.VChatTalk.command.CommandResult;
-import org.example.VChatTalk.command.CommandType;
+import org.example.VChatTalk.command.MessageConstants;
 import org.example.VChatTalk.model.MessageDTO;
-import org.example.VChatTalk.model.MessageType;
+import org.example.VChatTalk.service.BroadcastService;
 import org.example.VChatTalk.service.ChatService;
-import org.example.VChatTalk.util.SessionRegistry;
-import org.example.VChatTalk.util.SystemResponseSender;
-import org.junit.jupiter.api.AfterEach;
+import org.example.VChatTalk.service.MessageProcessor;
+import org.example.VChatTalk.util.*;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
+import java.util.List;
+
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ChatWebSocketHandlerTest {
 
-    @Mock
-    private SessionRegistry sessionRegistry;
-    @Mock
-    private ChatService chatService;
-    @Mock
-    private CommandParserService commandParserService;
-    @Mock
-    private WebSocketSession session;
-    @Mock
-    private CommandExecutor commandExecutor;
-    @Mock
-    private SystemResponseSender systemResponseSender;
+    @Mock private SessionRegistry sessionRegistry;
+    @Mock private UserRegistry userRegistry;
+    @Mock private PrivateChatRegistry privateChatRegistry;
+    @Mock private ChatService chatService;
+    @Mock private MessageProcessor messageProcessor;
+    @Mock private BroadcastService broadcastService;
+    @Mock private RateLimiter rateLimiter;
+    @Mock private SystemResponseSender systemResponseSender;
+    @Mock private WebSocketSession session;
 
+    @InjectMocks
+    private ChatWebSocketHandler chatWebSocketHandler;
 
-    private ChatWebSocketHandler handler;
-    private final ObjectMapper mapper = new ObjectMapper()
-            .registerModule(new JavaTimeModule())
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
+    private final String SESSION_ID = "test-session-id";
 
     @BeforeEach
     void setUp() {
-        // Mock leniently to avoid UnnecessaryStubbingException if test fails early
-        handler = new ChatWebSocketHandler(sessionRegistry, chatService, commandParserService, mapper, commandExecutor, systemResponseSender);
-        lenient().when(session.getId()).thenReturn("session-123");
+        lenient().when(session.getId()).thenReturn(SESSION_ID);
     }
 
-    // [IMPORTANT] Clean up session after each test to reset Rate Limit
-    @AfterEach
-    void tearDown() {
-        // This will remove session-123 from the lastMessageTime map
-        handler.afterConnectionClosed(session, CloseStatus.NORMAL);
+    // ========== CONNECTION TESTS ==========
+
+    @Test
+    @DisplayName("On Connect: Should register session and send welcome")
+    void afterConnectionEstablished_Success() throws Exception {
+        chatWebSocketHandler.afterConnectionEstablished(session);
+
+        verify(sessionRegistry).addSession(session);
+        verify(systemResponseSender).sendSystem(session, MessageConstants.MSG_WELCOME);
     }
 
     @Test
-    void testSelect_ValidOnlineUser_ShouldSetTarget() throws Exception {
-        // GIVEN
-        String command = "/select Alice";
-        String senderName = "Bob";
-        String targetName = "Alice";
-
-        when(sessionRegistry.isUserRegistered("session-123")).thenReturn(true);
-        when(commandParserService.parse(command)).thenReturn(new CommandResult(CommandType.SELECT, targetName, null));
-        when(sessionRegistry.getUsername("session-123")).thenReturn(senderName);
-        when(sessionRegistry.isUserOnline(targetName)).thenReturn(true); // Updated to match renamed method
-
-        // WHEN
-        MessageDTO dto = new MessageDTO();
-        dto.setType(MessageType.MESSAGE);
-        dto.setContent(command);
-        String payload = mapper.writeValueAsString(dto);
-
-        handler.handleTextMessage(session, new TextMessage(payload));
-
-        // THEN
-        verify(sessionRegistry).setTarget("session-123", targetName);
-
-        ArgumentCaptor<TextMessage> messageCaptor = ArgumentCaptor.forClass(TextMessage.class);
-        verify(session, atLeastOnce()).sendMessage(messageCaptor.capture());
-
-        String sentMessage = messageCaptor.getValue().getPayload();
-        assertTrue(sentMessage.contains("Switched to private chat"), "Should contain success message");
-    }
-
-    @Test
-    void testSelect_OfflineUser_ShouldSendError() throws Exception {
-        // GIVEN
-        String targetName = "GhostUser";
-
-        when(sessionRegistry.isUserRegistered("session-123")).thenReturn(true);
-        when(commandParserService.parse(anyString())).thenReturn(new CommandResult(CommandType.SELECT, targetName, null));
-        when(sessionRegistry.getUsername("session-123")).thenReturn("Bob");
-        when(sessionRegistry.isUserOnline(targetName)).thenReturn(false);
-
-        // WHEN
-        MessageDTO dto = new MessageDTO();
-        dto.setType(MessageType.MESSAGE);
-        dto.setContent("/select GhostUser");
-        handler.handleTextMessage(session, new TextMessage(mapper.writeValueAsString(dto)));
-
-        // THEN
-        verify(sessionRegistry, never()).setTarget(anyString(), anyString());
-
-        ArgumentCaptor<TextMessage> messageCaptor = ArgumentCaptor.forClass(TextMessage.class);
-        verify(session).sendMessage(messageCaptor.capture());
-        assertTrue(messageCaptor.getValue().getPayload().contains("offline") ||
-                        messageCaptor.getValue().getPayload().contains("ERROR"),
-                "Should report offline user error");
-    }
-
-    @Test
-    void testSelect_Self_ShouldSendError() throws Exception {
-        // GIVEN
-        String myName = "Bob";
-
-        when(sessionRegistry.isUserRegistered("session-123")).thenReturn(true);
-        when(commandParserService.parse(anyString())).thenReturn(new CommandResult(CommandType.SELECT, myName, null));
-        when(sessionRegistry.getUsername("session-123")).thenReturn(myName);
-
-        // WHEN
-        MessageDTO dto = new MessageDTO();
-        dto.setType(MessageType.MESSAGE);
-        dto.setContent("/select Bob");
-        handler.handleTextMessage(session, new TextMessage(mapper.writeValueAsString(dto)));
-
-        // THEN
-        verify(sessionRegistry, never()).setTarget(anyString(), anyString());
-
-        ArgumentCaptor<TextMessage> messageCaptor = ArgumentCaptor.forClass(TextMessage.class);
-        verify(session).sendMessage(messageCaptor.capture());
-        assertTrue(messageCaptor.getValue().getPayload().contains("yourself"), "Should report self-chat error");
-    }
-
-    @Test
-    void testDisconnect_ShouldNotifyFollowersAndClearTarget() throws Exception {
-        // --- GIVEN ---
-
-        // 1. Simulate the leaver (Alice)
-        String leaverSessionId = "session-Alice";
-        String leaverName = "Alice";
-        WebSocketSession leaverSession = mock(WebSocketSession.class);
-        when(leaverSession.getId()).thenReturn(leaverSessionId);
-
-        // 2. Simulate the follower (Bob)
-        String followerSessionId = "session-Bob";
+    @DisplayName("On Disconnect: Should cleanup and notify followers")
+    void afterConnectionClosed_Success() {
+        String username = "Alice";
+        String followerId = "follower-session";
         WebSocketSession followerSession = mock(WebSocketSession.class);
-        when(followerSession.isOpen()).thenReturn(true); // Bob is online
 
-        // --- MOCKING BEHAVIOR ---
+        // Setup user info
+        when(userRegistry.getUsername(SESSION_ID)).thenReturn(username);
+        when(chatService.handleLeave(SESSION_ID)).thenReturn(MessageDTO.builder().content("Bye").build());
 
-        // Return Alice when asking for leaver's username
-        when(sessionRegistry.getUsername(leaverSessionId)).thenReturn(leaverName);
+        // Setup a follower (someone private chatting with Alice)
+        when(privateChatRegistry.getSessionsTargeting(username)).thenReturn(List.of(followerId));
+        when(sessionRegistry.findSessionById(followerId)).thenReturn(followerSession);
+        when(followerSession.isOpen()).thenReturn(true);
 
-        // Return Bob when asking "Who is targeting Alice?"
-        when(sessionRegistry.getSessionsTargeting(leaverName)).thenReturn(java.util.List.of(followerSessionId));
+        chatWebSocketHandler.afterConnectionClosed(session, CloseStatus.NORMAL);
 
-        // Return mock followerSession when Handler looks up Bob's session
-        when(sessionRegistry.findSessionById(followerSessionId)).thenReturn(followerSession);
+        // Verify Cleanup
+        verify(rateLimiter).removeSession(SESSION_ID);
+        verify(sessionRegistry).removeSession(SESSION_ID);
+        verify(broadcastService).broadcast(any(MessageDTO.class), eq(null));
 
-        // --- WHEN ---
-        // Call connection closed handler for Alice
-        handler.afterConnectionClosed(leaverSession, CloseStatus.NORMAL);
+        // Verify Follower Notification
+        verify(privateChatRegistry).removeTarget(followerId);
+        try {
+            verify(systemResponseSender).sendSystem(eq(followerSession), anyString());
+        } catch (Exception e) { /* ignored for test */ }
+    }
 
-        // --- THEN ---
+    // ========== MESSAGE TESTS ==========
 
-        // 1. Verify: Bob's target must be removed
-        verify(sessionRegistry).removeTarget(followerSessionId);
+    @Test
+    @DisplayName("On Message: Should delegate to processor if within rate limit")
+    void handleTextMessage_Success() throws Exception {
+        TextMessage rawMessage = new TextMessage("{\"type\":\"MESSAGE\", \"content\":\"Hi\"}");
 
-        // 2. Verify: Notification sent to Bob
-        ArgumentCaptor<TextMessage> messageCaptor = ArgumentCaptor.forClass(TextMessage.class);
-        verify(followerSession).sendMessage(messageCaptor.capture());
+        when(rateLimiter.isRateLimitExceeded(SESSION_ID)).thenReturn(false);
 
-        String sentMessage = messageCaptor.getValue().getPayload();
-        // Verify message content
-        assertTrue(sentMessage.contains("Private chat ended"), "Bob should receive private chat ended notification");
-        assertTrue(sentMessage.contains(leaverName), "Notification should contain leaver's name");
+        chatWebSocketHandler.handleTextMessage(session, rawMessage);
+
+        verify(messageProcessor).processMessage(session, rawMessage.getPayload());
     }
 
     @Test
-    void testSelect_UnregisteredUser_ShouldSendError() throws Exception {
-        // GIVEN
-        String command = "/select Alice";
+    @DisplayName("On Message: Should block and send error if rate limit exceeded")
+    void handleTextMessage_RateLimited() throws Exception {
+        TextMessage rawMessage = new TextMessage("Spam message");
 
-        // [FIX]: Add lenient() to avoid UnnecessaryStubbingException
-        // (In case logic checks user registration before parsing command)
-        lenient().when(sessionRegistry.isUserRegistered("session-123")).thenReturn(false);
+        when(rateLimiter.isRateLimitExceeded(SESSION_ID)).thenReturn(true);
 
-        // [FIX]: Add lenient() for parsing as well
-        lenient().when(commandParserService.parse(command)).thenReturn(new CommandResult(CommandType.SELECT, "Alice", null));
+        chatWebSocketHandler.handleTextMessage(session, rawMessage);
 
-        // WHEN
-        MessageDTO dto = new MessageDTO();
-        dto.setType(MessageType.MESSAGE);
-        dto.setContent(command);
-
-        handler.handleTextMessage(session, new TextMessage(mapper.writeValueAsString(dto)));
-
-        // THEN
-        // 1. Ensure setTarget is NEVER called
-        verify(sessionRegistry, never()).setTarget(anyString(), anyString());
-
-        // 2. Should send error message
-        ArgumentCaptor<TextMessage> messageCaptor = ArgumentCaptor.forClass(TextMessage.class);
-        verify(session).sendMessage(messageCaptor.capture());
-
-        String sentMessage = messageCaptor.getValue().getPayload();
-        assertTrue(sentMessage.contains("must join"), "Should require user to join first");
+        verify(systemResponseSender).sendError(session, MessageConstants.ERR_RATE_LIMIT);
+        verifyNoInteractions(messageProcessor);
     }
 }

--- a/src/test/java/org/example/VChatTalk/service/BroadcastServiceTest.java
+++ b/src/test/java/org/example/VChatTalk/service/BroadcastServiceTest.java
@@ -1,0 +1,125 @@
+package org.example.VChatTalk.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.VChatTalk.model.MessageDTO;
+import org.example.VChatTalk.model.MessageType;
+import org.example.VChatTalk.util.SessionRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BroadcastServiceTest {
+
+    @Mock private SessionRegistry sessionRegistry;
+
+    // Use a Spy for ObjectMapper to test real serialization
+    @Spy private ObjectMapper mapper = new ObjectMapper();
+
+    @InjectMocks
+    private BroadcastService broadcastService;
+
+    private WebSocketSession sessionA;
+    private WebSocketSession sessionB;
+    private MessageDTO messageDto;
+
+    @BeforeEach
+    void setUp() {
+        sessionA = mock(WebSocketSession.class);
+        sessionB = mock(WebSocketSession.class);
+
+        lenient().when(sessionA.getId()).thenReturn("id-a");
+        lenient().when(sessionB.getId()).thenReturn("id-b");
+        lenient().when(sessionA.isOpen()).thenReturn(true);
+        lenient().when(sessionB.isOpen()).thenReturn(true);
+
+        messageDto = MessageDTO.builder()
+                .sender("Alice")
+                .content("Hello")
+                .type(MessageType.MESSAGE)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Broadcast - Should send to everyone except sender")
+    void broadcast_ExcludeSender() throws IOException {
+        // Arrange: Alice (sessionA) sends a message
+        when(sessionRegistry.getAllSessions()).thenReturn(List.of(sessionA, sessionB));
+
+        // Act
+        broadcastService.broadcast(messageDto, sessionA);
+
+        // Assert: sessionB receives it, sessionA does not
+        verify(sessionB, times(1)).sendMessage(any(TextMessage.class));
+        verify(sessionA, never()).sendMessage(any(TextMessage.class));
+    }
+
+    @Test
+    @DisplayName("Broadcast - System message should be sent to everyone")
+    void broadcast_SystemMessage() throws IOException {
+        // Arrange: System message (sender is null)
+        when(sessionRegistry.getAllSessions()).thenReturn(List.of(sessionA, sessionB));
+
+        // Act
+        broadcastService.broadcast(messageDto, null);
+
+        // Assert: Both sessions receive it
+        verify(sessionA, times(1)).sendMessage(any(TextMessage.class));
+        verify(sessionB, times(1)).sendMessage(any(TextMessage.class));
+    }
+
+    @Test
+    @DisplayName("Broadcast - Should skip closed sessions")
+    void broadcast_SkipClosedSession() throws IOException {
+        // Arrange: Session B is closed
+        when(sessionB.isOpen()).thenReturn(false);
+        when(sessionRegistry.getAllSessions()).thenReturn(List.of(sessionA, sessionB));
+
+        // Act: System broadcast
+        broadcastService.broadcast(messageDto, null);
+
+        // Assert: Only A gets it
+        verify(sessionA, times(1)).sendMessage(any(TextMessage.class));
+        verify(sessionB, never()).sendMessage(any(TextMessage.class));
+    }
+
+    @Test
+    @DisplayName("sendToSession - Should send message to specific user")
+    void sendToSession_Success() throws IOException {
+        // Act
+        broadcastService.sendToSession(sessionA, messageDto);
+
+        // Assert
+        verify(sessionA, times(1)).sendMessage(any(TextMessage.class));
+        // Verify JSON content (optional check)
+        String expectedJson = mapper.writeValueAsString(messageDto);
+        verify(sessionA).sendMessage(new TextMessage(expectedJson));
+    }
+
+    @Test
+    @DisplayName("Broadcast - Should continue if one session fails")
+    void broadcast_FailureInOneSession() throws IOException {
+        // Arrange: Session A throws error, but session B should still work
+        when(sessionRegistry.getAllSessions()).thenReturn(List.of(sessionA, sessionB));
+        doThrow(new IOException("Network error")).when(sessionA).sendMessage(any(TextMessage.class));
+
+        // Act
+        broadcastService.broadcast(messageDto, null);
+
+        // Assert
+        verify(sessionA).sendMessage(any(TextMessage.class)); // Attempted
+        verify(sessionB).sendMessage(any(TextMessage.class)); // Still executed
+    }
+}

--- a/src/test/java/org/example/VChatTalk/service/ChatServiceTest.java
+++ b/src/test/java/org/example/VChatTalk/service/ChatServiceTest.java
@@ -1,75 +1,141 @@
 package org.example.VChatTalk.service;
 
 import org.example.VChatTalk.model.MessageDTO;
+import org.example.VChatTalk.model.MessageType;
+import org.example.VChatTalk.util.PrivateChatRegistry;
 import org.example.VChatTalk.util.SessionRegistry;
+import org.example.VChatTalk.util.UserRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.socket.WebSocketSession;
 
-import java.util.Collection;
-import java.util.Collections;
+import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ChatServiceTest {
 
-    @Mock
-    private SessionRegistry sessionRegistry;
+    @Mock private SessionRegistry sessionRegistry;
+    @Mock private UserRegistry userRegistry;
+    @Mock private PrivateChatRegistry privateChatRegistry;
+    @Mock private BroadcastService broadcastService;
+    @Mock private WebSocketSession senderSession;
 
     @InjectMocks
     private ChatService chatService;
 
-    // Test Case 1: Duplicate username registration (Race Condition Logic) -> Should throw exception
-    @Test
-    void testHandleJoin_DuplicateUsername_ShouldThrowException() {
-        // GIVEN
-        String sessionId = "session-new-user";
-        String duplicateName = "Alice";
+    private final String SENDER_ID = "session-123";
+    private final String SENDER_NAME = "Alice";
 
-        MessageDTO joinDto = new MessageDTO();
-        joinDto.setSender(duplicateName);
-
-        // Mock: User is not registered yet
-        when(sessionRegistry.isUserRegistered(sessionId)).thenReturn(false);
-
-        // Mock: tryRegisterUser returns FALSE (simulating race condition or taken name)
-        when(sessionRegistry.tryRegisterUser(sessionId, duplicateName)).thenReturn(false);
-
-        // WHEN & THEN
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            chatService.handleJoin(sessionId, joinDto);
-        });
-
-        assertEquals("Username 'Alice' is already taken. Please choose another.", exception.getMessage());
+    @BeforeEach
+    void setUp() {
+        lenient().when(senderSession.getId()).thenReturn(SENDER_ID);
     }
 
-    // Test Case 2: Successful registration (Happy Path)
+    // ========== JOIN TESTS ==========
+
     @Test
-    void testHandleJoin_ValidUsername_ShouldSucceed() {
-        // GIVEN
-        String sessionId = "session-123";
-        String newName = "Bob";
-        MessageDTO joinDto = new MessageDTO();
-        joinDto.setSender(newName);
+    @DisplayName("Join - Should succeed when username is valid and available")
+    void handleJoin_Success() {
+        MessageDTO joinDto = MessageDTO.builder().sender("Alice!").build(); // '!' should be sanitized
 
-        when(sessionRegistry.isUserRegistered(sessionId)).thenReturn(false);
-        when(sessionRegistry.tryRegisterUser(sessionId, newName)).thenReturn(true);
+        when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(false);
+        when(userRegistry.tryRegisterUser(eq(SENDER_ID), eq("Alice"))).thenReturn(true);
+        when(userRegistry.countOnlineUsers()).thenReturn(1);
 
-        // Mock getAllSessions returning a Collection (size = 1)
-        Collection<WebSocketSession> mockSessions = Collections.singletonList(mock(WebSocketSession.class));
-        when(sessionRegistry.getAllSessions()).thenReturn(mockSessions);
+        MessageDTO result = chatService.handleJoin(SENDER_ID, joinDto);
 
-        // WHEN
-        MessageDTO result = chatService.handleJoin(sessionId, joinDto);
+        assertNotNull(result);
+        assertEquals(MessageType.SYSTEM, result.getType());
+        assertTrue(result.getContent().contains("Alice"));
+        verify(userRegistry).tryRegisterUser(SENDER_ID, "Alice");
+    }
 
-        // THEN
-        verify(sessionRegistry).tryRegisterUser(sessionId, newName);
-        assertEquals("Bob has joined the chat. (Total: 1)", result.getContent());
+    @Test
+    @DisplayName("Join - Should throw exception if username is already taken")
+    void handleJoin_DuplicateUsername() {
+        MessageDTO joinDto = MessageDTO.builder().sender("Bob").build();
+        when(userRegistry.tryRegisterUser(anyString(), anyString())).thenReturn(false);
+
+        assertThrows(IllegalArgumentException.class, () -> chatService.handleJoin(SENDER_ID, joinDto));
+    }
+
+    // ========== ROUTING TESTS ==========
+
+    @Test
+    @DisplayName("Route - Should broadcast to global when no private target is set")
+    void routeMessage_GlobalMode() throws IOException {
+        MessageDTO dto = MessageDTO.builder().content("Hello World").build();
+
+        when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
+        when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
+        when(privateChatRegistry.getTarget(SENDER_ID)).thenReturn(null);
+
+        chatService.routeMessage(senderSession, dto);
+
+        verify(broadcastService).broadcast(any(MessageDTO.class), eq(senderSession));
+        verify(broadcastService, never()).sendToSession(any(), any());
+    }
+
+    @Test
+    @DisplayName("Route - Should send private message when target is set")
+    void routeMessage_PrivateMode() throws IOException {
+        String targetName = "Bob";
+        String targetSessId = "session-456";
+        WebSocketSession targetSession = mock(WebSocketSession.class);
+
+        MessageDTO dto = MessageDTO.builder().content("Secret").build();
+
+        // Setup registries
+        when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
+        when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
+        when(privateChatRegistry.getTarget(SENDER_ID)).thenReturn(targetName);
+
+        // Setup Bob's availability
+        when(userRegistry.getSessionId(targetName)).thenReturn(targetSessId);
+        when(sessionRegistry.findSessionById(targetSessId)).thenReturn(targetSession);
+        when(targetSession.isOpen()).thenReturn(true);
+
+        chatService.routeMessage(senderSession, dto);
+
+        // Verify Bob gets the message and Alice gets an echo
+        verify(broadcastService, times(2)).sendToSession(any(), any());
+
+        // Verify formatting for Target
+        ArgumentCaptor<MessageDTO> msgCaptor = ArgumentCaptor.forClass(MessageDTO.class);
+        verify(broadcastService).sendToSession(eq(targetSession), msgCaptor.capture());
+        assertTrue(msgCaptor.getValue().getContent().contains("[PM]"));
+    }
+
+    // ========== LEAVE TESTS ==========
+
+    @Test
+    @DisplayName("Leave - Should remove user and return system message")
+    void handleLeave_Success() {
+        when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
+        when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
+
+        MessageDTO result = chatService.handleLeave(SENDER_ID);
+
+        assertNotNull(result);
+        verify(userRegistry).removeUser(SENDER_ID);
+        verify(privateChatRegistry).removeTarget(SENDER_ID);
+    }
+
+    @Test
+    @DisplayName("Message - Should throw exception if user sends message without joining")
+    void handleMessage_Unregistered() {
+        MessageDTO dto = MessageDTO.builder().content("Hi").build();
+        when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(false);
+
+        assertThrows(IllegalStateException.class, () -> chatService.handleMessage(SENDER_ID, dto));
     }
 }

--- a/src/test/java/org/example/VChatTalk/service/MessageProcessorTest.java
+++ b/src/test/java/org/example/VChatTalk/service/MessageProcessorTest.java
@@ -1,0 +1,123 @@
+package org.example.VChatTalk.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.VChatTalk.command.CommandExecutor;
+import org.example.VChatTalk.command.CommandResult;
+import org.example.VChatTalk.command.CommandType;
+import org.example.VChatTalk.command.MessageConstants;
+import org.example.VChatTalk.command.service.CommandParserService;
+import org.example.VChatTalk.model.MessageDTO;
+import org.example.VChatTalk.model.MessageType;
+import org.example.VChatTalk.util.SystemResponseSender;
+import org.example.VChatTalk.util.UserRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MessageProcessorTest {
+
+    @Mock private UserRegistry userRegistry;
+    @Mock private ChatService chatService;
+    @Mock private CommandParserService commandParserService;
+    @Mock private CommandExecutor commandExecutor;
+    @Mock private SystemResponseSender systemResponseSender;
+    @Mock private BroadcastService broadcastService;
+    @Mock private WebSocketSession session;
+
+    // We use a real ObjectMapper to simulate actual JSON parsing
+    @Spy
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @InjectMocks
+    private MessageProcessor messageProcessor;
+
+    private final String SESSION_ID = "sess-999";
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(session.getId()).thenReturn(SESSION_ID);
+    }
+
+    @Test
+    @DisplayName("JOIN: Should call chatService.handleJoin and broadcast")
+    void processMessage_JoinType() throws IOException {
+        String payload = "{\"type\":\"JOIN\", \"sender\":\"Alice\"}";
+        MessageDTO systemMsg = MessageDTO.builder().type(MessageType.SYSTEM).content("Joined").build();
+
+        when(chatService.handleJoin(eq(SESSION_ID), any())).thenReturn(systemMsg);
+
+        boolean result = messageProcessor.processMessage(session, payload);
+
+        assertTrue(result);
+        verify(chatService).handleJoin(eq(SESSION_ID), any());
+        verify(broadcastService).broadcast(systemMsg, null);
+        verify(systemResponseSender).sendSystem(session, MessageConstants.MSG_JOINED_SUCCESS);
+    }
+
+    @Test
+    @DisplayName("COMMAND: Should route '/list' to CommandExecutor")
+    void processMessage_CommandRoute() throws IOException {
+        String payload = "{\"type\":\"MESSAGE\", \"content\":\"/list\"}";
+        CommandResult mockResult = new CommandResult(CommandType.LIST, null, null);
+
+        when(commandParserService.parse("/list")).thenReturn(mockResult);
+        when(userRegistry.isUserRegistered(SESSION_ID)).thenReturn(true);
+
+        boolean result = messageProcessor.processMessage(session, payload);
+
+        assertTrue(result);
+        verify(commandExecutor).execute(session, mockResult);
+        verifyNoInteractions(chatService); // Should not go to chat logic
+    }
+
+    @Test
+    @DisplayName("CHAT: Should route regular text to ChatService")
+    void processMessage_ChatRoute() throws IOException {
+        String payload = "{\"type\":\"MESSAGE\", \"content\":\"Hello world\"}";
+
+        when(userRegistry.isUserRegistered(SESSION_ID)).thenReturn(true);
+
+        boolean result = messageProcessor.processMessage(session, payload);
+
+        assertTrue(result);
+        verify(chatService).routeMessage(eq(session), any(MessageDTO.class));
+        verifyNoInteractions(commandExecutor);
+    }
+
+    @Test
+    @DisplayName("SECURITY: Should reject message if user not logged in")
+    void processMessage_UnregisteredUser() throws IOException {
+        String payload = "{\"type\":\"MESSAGE\", \"content\":\"I am a hacker\"}";
+
+        when(userRegistry.isUserRegistered(SESSION_ID)).thenReturn(false);
+
+        boolean result = messageProcessor.processMessage(session, payload);
+
+        assertFalse(result);
+        verify(systemResponseSender).sendError(session, MessageConstants.ERR_SEND_MUST_LOGIN);
+        verifyNoInteractions(chatService);
+    }
+
+    @Test
+    @DisplayName("ERROR: Should handle invalid JSON gracefully")
+    void processMessage_InvalidJson() throws IOException {
+        String payload = "not-a-json-string";
+
+        boolean result = messageProcessor.processMessage(session, payload);
+
+        assertFalse(result);
+        verify(systemResponseSender).sendError(session, MessageConstants.ERR_INVALID_JSON);
+    }
+}

--- a/src/test/java/org/example/VChatTalk/util/RateLimiterTest.java
+++ b/src/test/java/org/example/VChatTalk/util/RateLimiterTest.java
@@ -1,0 +1,79 @@
+package org.example.VChatTalk.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RateLimiterTest {
+
+    private RateLimiter rateLimiter;
+    private final String SESSION_ID = "test-session-001";
+
+    @BeforeEach
+    void setUp() {
+        rateLimiter = new RateLimiter();
+        rateLimiter.clear(); // Ensure a clean state before each test
+    }
+
+    @Test
+    @DisplayName("First message should not be rate limited")
+    void isRateLimitExceeded_FirstMessage_Success() {
+        boolean exceeded = rateLimiter.isRateLimitExceeded(SESSION_ID);
+        assertFalse(exceeded, "The first message from a session should always be allowed.");
+    }
+
+    @Test
+    @DisplayName("Rapid subsequent messages should be blocked as spam")
+    void isRateLimitExceeded_TooFast_ReturnsTrue() {
+        // First message allowed
+        rateLimiter.isRateLimitExceeded(SESSION_ID);
+
+        // Immediate second message (within < 200ms)
+        boolean exceeded = rateLimiter.isRateLimitExceeded(SESSION_ID);
+
+        assertTrue(exceeded, "Messages sent within less than 200ms should trigger the rate limit.");
+    }
+
+    @Test
+    @DisplayName("Message after the 200ms cooldown should be allowed")
+    void isRateLimitExceeded_AfterWait_Success() throws InterruptedException {
+        rateLimiter.isRateLimitExceeded(SESSION_ID);
+
+        // Wait for 250ms (exceeding the 200ms limit)
+        Thread.sleep(250);
+
+        boolean exceeded = rateLimiter.isRateLimitExceeded(SESSION_ID);
+        assertFalse(exceeded, "Message should be allowed after waiting for the cooldown period.");
+    }
+
+    @Test
+    @DisplayName("Different sessions should have independent rate limits")
+    void isRateLimitExceeded_SessionsAreIndependent() {
+        String sessionA = "User-A";
+        String sessionB = "User-B";
+
+        // User A sends a message
+        rateLimiter.isRateLimitExceeded(sessionA);
+
+        // User B sends a message immediately after
+        boolean exceededB = rateLimiter.isRateLimitExceeded(sessionB);
+
+        assertFalse(exceededB, "Rate limit for User A should not affect User B.");
+    }
+
+    @Test
+    @DisplayName("Removing a session should reset its rate limit tracking")
+    void removeSession_ResetsTracking() {
+        // Trigger rate limit for session
+        rateLimiter.isRateLimitExceeded(SESSION_ID);
+
+        // Remove tracking for this session
+        rateLimiter.removeSession(SESSION_ID);
+
+        // Should be allowed to send again immediately
+        boolean exceeded = rateLimiter.isRateLimitExceeded(SESSION_ID);
+        assertFalse(exceeded, "Session should be able to send messages immediately after removal from registry.");
+    }
+}


### PR DESCRIPTION
📝 Summary
Refactor ChatWebSocketHandler and related services to comply with Single Responsibility Principle (SRP). Split logic into independent services that are easier to test and maintain.
🔧 Changes Made
New Files
BroadcastService.java - Message broadcasting
MessageProcessor.java - Message parsing/routing
RateLimiter.java - Spam prevention
Modified Files
ChatWebSocketHandler.java - Lifecycle only
ChatService.java - Business logic with 3 registries
✅ Benefits
SRP compliance - 1 responsibility per class
Easy unit testing - injectable dependencies
Clean separation - session/user/target management
📸 Before/After
Before:
ChatWebSocketHandler: 250+ lines, 6 responsibilities
After:
ChatWebSocketHandler: 120 lines, lifecycle only
3 separate registries (Session/User/PrivateChat)
3 new services (Broadcast/MessageProcessor/RateLimiter)