### PR TITLE
US-6.1 Feature/create RoomRegistry

### DIFF
--- a/src/main/java/org/example/VChatTalk/util/RoomRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/RoomRegistry.java
@@ -1,0 +1,127 @@
+package org.example.VChatTalk.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages the lifecycle of chat rooms and their members.
+ * <p>
+ * <strong>Invariant:</strong> A session can only be in ONE room at a time.
+ * <p>
+ * <strong>Design Note:</strong>
+ * {@code sessionRoomIndex} is the Source of Truth for "Where is this user?".
+ * {@code roomSessions} is the derived view for "Who is in this room?".
+ * Consistency is eventual (nanoseconds) but sufficient for chat requirements.
+ */
+@Slf4j
+@Component
+public class RoomRegistry {
+
+    // Room ID -> Set of Session IDs
+    private final ConcurrentHashMap<String, Set<String>> roomSessions = new ConcurrentHashMap<>();
+
+    // Session ID -> Room ID (Primary Index for Invariant enforcement)
+    private final ConcurrentHashMap<String, String> sessionRoomIndex = new ConcurrentHashMap<>();
+
+    /**
+     * Add a session to a room.
+     * Auto-removes session from previous room if necessary.
+     */
+    public void joinRoom(String roomId, String sessionId) {
+        // Validation: Fail fast for programming errors, but use DEBUG to reduce noise
+        if (roomId == null || !roomId.startsWith("#")) {
+            log.debug("Join failed: Invalid roomId format '{}'", roomId);
+            throw new IllegalArgumentException("Room ID must start with '#'");
+        }
+        if (sessionId == null) {
+            log.debug("Join failed: sessionId is null");
+            return;
+        }
+
+        // 1. Invariant Enforcement: Atomically update index
+        String previousRoom = sessionRoomIndex.put(sessionId, roomId);
+
+        // Auto-leave previous room if different
+        if (previousRoom != null && !previousRoom.equals(roomId)) {
+            log.debug("Auto-leaving room [{}] to join [{}]", previousRoom, roomId);
+            removeFromRoomSet(previousRoom, sessionId);
+        }
+
+        // 2. Update Derived View
+        roomSessions.computeIfAbsent(roomId, k -> ConcurrentHashMap.newKeySet())
+                .add(sessionId);
+
+        log.info("Session [{}] joined room [{}]", sessionId, roomId);
+    }
+
+    /**
+     * Remove a session from a specific room.
+     */
+    public void leaveRoom(String roomId, String sessionId) {
+        if (roomId == null || sessionId == null) {
+            log.debug("Leave failed: null params");
+            return;
+        }
+
+        // 1. Remove from Index (Source of Truth)
+        boolean removed = sessionRoomIndex.remove(sessionId, roomId);
+
+        if (removed) {
+            // 2. Update Derived View
+            removeFromRoomSet(roomId, sessionId);
+            log.info("Session [{}] left room [{}]", sessionId, roomId);
+        }
+    }
+
+    /**
+     * Convenience method to leave whatever room the user is currently in.
+     * Simplifies the LeaveCommand logic.
+     */
+    public void leaveCurrentRoom(String sessionId) {
+        if (sessionId == null) return;
+
+        String currentRoom = sessionRoomIndex.get(sessionId);
+        if (currentRoom != null) {
+            leaveRoom(currentRoom, sessionId);
+        }
+    }
+
+    /**
+     * Helper to clean up roomSessions map
+     */
+    private void removeFromRoomSet(String roomId, String sessionId) {
+        Set<String> members = roomSessions.get(roomId);
+        if (members != null) {
+            members.remove(sessionId);
+            if (members.isEmpty()) {
+                roomSessions.remove(roomId);
+                log.debug("Room [{}] is empty and removed", roomId);
+            }
+        }
+    }
+
+    /**
+     * Get all members of a specific room.
+     */
+    public Set<String> getRoomMembers(String roomId) {
+        if (roomId == null) return Collections.emptySet();
+
+        Set<String> members = roomSessions.get(roomId);
+        if (members == null) return Collections.emptySet();
+
+        return Collections.unmodifiableSet(members);
+    }
+
+    /**
+     * Find which room a specific session is currently in.
+     */
+    public Optional<String> getRoomOfSession(String sessionId) {
+        if (sessionId == null) return Optional.empty();
+        return Optional.ofNullable(sessionRoomIndex.get(sessionId));
+    }
+}

--- a/src/main/java/org/example/VChatTalk/util/RoomRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/RoomRegistry.java
@@ -34,13 +34,13 @@ public class RoomRegistry {
      */
     public void joinRoom(String roomId, String sessionId) {
         // Validation: Fail fast for programming errors, but use DEBUG to reduce noise
-        if (roomId == null || !roomId.startsWith("#")) {
+        if (roomId == null || !roomId.startsWith("#") || roomId.length() <= 1) {
             log.debug("Join failed: Invalid roomId format '{}'", roomId);
-            throw new IllegalArgumentException("Room ID must start with '#'");
+            throw new IllegalArgumentException("Room ID must start with '#' and contain a name");
         }
         if (sessionId == null) {
             log.debug("Join failed: sessionId is null");
-            return;
+            throw new IllegalArgumentException("Session ID must not be null");
         }
 
         // 1. Invariant Enforcement: Atomically update index
@@ -95,14 +95,14 @@ public class RoomRegistry {
      * Helper to clean up roomSessions map
      */
     private void removeFromRoomSet(String roomId, String sessionId) {
-        Set<String> members = roomSessions.get(roomId);
-        if (members != null) {
+        roomSessions.computeIfPresent(roomId, (id, members) -> {
             members.remove(sessionId);
             if (members.isEmpty()) {
-                roomSessions.remove(roomId);
                 log.debug("Room [{}] is empty and removed", roomId);
+                return null; // remove this room from the map
             }
-        }
+            return members;
+        });
     }
 
     /**

--- a/src/main/java/org/example/VChatTalk/util/RoomRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/RoomRegistry.java
@@ -15,14 +15,10 @@ import java.util.concurrent.ConcurrentHashMap;
  * A session can only belong to ONE room at a time.
  *
  * Concurrency model:
- * Uses ConcurrentHashMap for thread-safe access to individual data structures.
- * However, compound operations (e.g. updating both sessionRoomIndex and roomSessions
- * in joinRoom) are NOT atomic.
+ * All public methods are synchronized to ensure STRONG CONSISTENCY.
+ * Compound operations across internal data structures are atomic.
  *
- * As a result, short-lived inconsistencies may be observable under concurrent access.
- * sessionRoomIndex is treated as the source of truth, and roomSessions is a derived view.
- *
- * If strict consistency is required, external synchronization must be applied.
+ * No observable inconsistencies are allowed under concurrent access.
  */
 
 @Slf4j
@@ -69,7 +65,7 @@ public class RoomRegistry {
     /**
      * Remove a session from a specific room.
      */
-    public void leaveRoom(String roomId, String sessionId) {
+    public synchronized void leaveRoom(String roomId, String sessionId) {
         if (roomId == null || sessionId == null) {
             log.debug("Leave failed: null params");
             return;
@@ -89,7 +85,7 @@ public class RoomRegistry {
      * Convenience method to leave whatever room the user is currently in.
      * Simplifies the LeaveCommand logic.
      */
-    public void leaveCurrentRoom(String sessionId) {
+    public synchronized void leaveCurrentRoom(String sessionId) {
         if (sessionId == null) return;
 
         String currentRoom = sessionRoomIndex.get(sessionId);
@@ -115,7 +111,7 @@ public class RoomRegistry {
     /**
      * Get all members of a specific room.
      */
-    public Set<String> getRoomMembers(String roomId) {
+    public synchronized Set<String> getRoomMembers(String roomId) {
         if (roomId == null) return Collections.emptySet();
 
         Set<String> members = roomSessions.get(roomId);
@@ -127,7 +123,7 @@ public class RoomRegistry {
     /**
      * Find which room a specific session is currently in.
      */
-    public Optional<String> getRoomOfSession(String sessionId) {
+    public synchronized Optional<String> getRoomOfSession(String sessionId) {
         if (sessionId == null) return Optional.empty();
         return Optional.ofNullable(sessionRoomIndex.get(sessionId));
     }

--- a/src/main/java/org/example/VChatTalk/util/RoomRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/RoomRegistry.java
@@ -10,14 +10,21 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Manages the lifecycle of chat rooms and their members.
- * <p>
- * <strong>Invariant:</strong> A session can only be in ONE room at a time.
- * <p>
- * <strong>Design Note:</strong>
- * {@code sessionRoomIndex} is the Source of Truth for "Where is this user?".
- * {@code roomSessions} is the derived view for "Who is in this room?".
- * Consistency is eventual (nanoseconds) but sufficient for chat requirements.
+ *
+ * Invariant:
+ * A session can only belong to ONE room at a time.
+ *
+ * Concurrency model:
+ * Uses ConcurrentHashMap for thread-safe access to individual data structures.
+ * However, compound operations (e.g. updating both sessionRoomIndex and roomSessions
+ * in joinRoom) are NOT atomic.
+ *
+ * As a result, short-lived inconsistencies may be observable under concurrent access.
+ * sessionRoomIndex is treated as the source of truth, and roomSessions is a derived view.
+ *
+ * If strict consistency is required, external synchronization must be applied.
  */
+
 @Slf4j
 @Component
 public class RoomRegistry {
@@ -32,7 +39,7 @@ public class RoomRegistry {
      * Add a session to a room.
      * Auto-removes session from previous room if necessary.
      */
-    public void joinRoom(String roomId, String sessionId) {
+    public synchronized void joinRoom(String roomId, String sessionId) {
         // Validation: Fail fast for programming errors, but use DEBUG to reduce noise
         if (roomId == null || !roomId.startsWith("#") || roomId.length() <= 1) {
             log.debug("Join failed: Invalid roomId format '{}'", roomId);

--- a/src/test/java/org/example/VChatTalk/util/RoomRegistryTest.java
+++ b/src/test/java/org/example/VChatTalk/util/RoomRegistryTest.java
@@ -3,7 +3,12 @@ package org.example.VChatTalk.util;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -16,79 +21,41 @@ class RoomRegistryTest {
         registry = new RoomRegistry();
     }
 
-    // ---------- joinRoom validation ----------
+    /* =========================
+       Validation tests
+       ========================= */
 
     @Test
-    void joinRoom_withNullRoomId_shouldThrowException() {
-        IllegalArgumentException ex = assertThrows(
-                IllegalArgumentException.class,
-                () -> registry.joinRoom(null, "s1")
-        );
+    void joinRoom_invalidRoomId_shouldThrowException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> registry.joinRoom("room", "s1"));
 
-        assertTrue(ex.getMessage().contains("Room ID"));
+        assertThrows(IllegalArgumentException.class,
+                () -> registry.joinRoom("#", "s1"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> registry.joinRoom("", "s1"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> registry.joinRoom(null, "s1"));
     }
 
-    @Test
-    void joinRoom_withEmptyRoomId_shouldThrowException() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> registry.joinRoom("", "s1")
-        );
-    }
-
-    @Test
-    void joinRoom_withHashOnlyRoomId_shouldThrowException() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> registry.joinRoom("#", "s1")
-        );
-    }
-
-    @Test
-    void joinRoom_withRoomIdWithoutHash_shouldThrowException() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> registry.joinRoom("room1", "s1")
-        );
-    }
-
-    @Test
-    void joinRoom_withNullSessionId_shouldThrowException() {
-        IllegalArgumentException ex = assertThrows(
-                IllegalArgumentException.class,
-                () -> registry.joinRoom("#room", null)
-        );
-
-        assertTrue(ex.getMessage().contains("Session ID"));
-    }
-
-    // ---------- joinRoom behavior ----------
+    /* =========================
+       Basic behavior tests
+       ========================= */
 
     @Test
     void joinRoom_shouldAddSessionToRoom() {
         registry.joinRoom("#room", "s1");
 
-        Set<String> members = registry.getRoomMembers("#room");
-        assertEquals(1, members.size());
-        assertTrue(members.contains("s1"));
-    }
-
-    @Test
-    void joinRoom_shouldAllowMultipleSessions() {
-        registry.joinRoom("#room", "s1");
-        registry.joinRoom("#room", "s2");
-
-        Set<String> members = registry.getRoomMembers("#room");
-        assertEquals(2, members.size());
-    }
-
-    @Test
-    void joinRoom_sameRoomTwice_shouldNotDuplicateSession() {
-        registry.joinRoom("#room", "s1");
-        registry.joinRoom("#room", "s1");
-
-        Set<String> members = registry.getRoomMembers("#room");
-        assertEquals(1, members.size());
+        assertEquals(
+                Set.of("s1"),
+                registry.getRoomMembers("#room")
+        );
+        assertEquals(
+                "#room",
+                registry.getRoomOfSession("s1").orElseThrow()
+        );
     }
 
     @Test
@@ -96,29 +63,17 @@ class RoomRegistryTest {
         registry.joinRoom("#room1", "s1");
         registry.joinRoom("#room2", "s1");
 
-        assertFalse(registry.getRoomMembers("#room1").contains("s1"));
-        assertTrue(registry.getRoomMembers("#room2").contains("s1"));
-    }
-
-    // ---------- getRoomOfSession ----------
-
-    @Test
-    void getRoomOfSession_shouldReturnEmpty_forUnknownSession() {
-        assertTrue(registry.getRoomOfSession("unknown").isEmpty());
+        assertTrue(registry.getRoomMembers("#room1").isEmpty());
+        assertEquals(
+                Set.of("s1"),
+                registry.getRoomMembers("#room2")
+        );
     }
 
     @Test
-    void getRoomOfSession_shouldReturnCurrentRoom() {
+    void leaveRoom_shouldRemoveSessionAndCleanupRoom() {
         registry.joinRoom("#room", "s1");
 
-        assertEquals("#room", registry.getRoomOfSession("s1").orElseThrow());
-    }
-
-    // ---------- leaveRoom ----------
-
-    @Test
-    void leaveRoom_shouldRemoveSession() {
-        registry.joinRoom("#room", "s1");
         registry.leaveRoom("#room", "s1");
 
         assertTrue(registry.getRoomMembers("#room").isEmpty());
@@ -126,17 +81,128 @@ class RoomRegistryTest {
     }
 
     @Test
-    void leaveRoom_withWrongRoom_shouldDoNothing() {
-        registry.joinRoom("#room1", "s1");
-        registry.leaveRoom("#room2", "s1");
+    void leaveRoom_nullArguments_shouldBeNoOp() {
+        registry.leaveRoom(null, null);
+        registry.leaveRoom("#room", null);
+        registry.leaveRoom(null, "s1");
+    }
 
-        assertTrue(registry.getRoomMembers("#room1").contains("s1"));
+    /* =========================
+       Concurrent tests
+       ========================= */
+
+    @Test
+    void joinRoom_concurrentJoins_shouldHandleCorrectly() throws InterruptedException {
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final String sessionId = "s" + i;
+            executor.submit(() -> {
+                try {
+                    registry.joinRoom("#room", sessionId);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        executor.shutdown();
+
+        Set<String> members = registry.getRoomMembers("#room");
+        assertEquals(threadCount, members.size());
+
+        for (int i = 0; i < threadCount; i++) {
+            assertEquals(
+                    "#room",
+                    registry.getRoomOfSession("s" + i).orElseThrow()
+            );
+        }
     }
 
     @Test
-    void leaveRoom_withNullArguments_shouldDoNothing() {
-        assertDoesNotThrow(() -> registry.leaveRoom(null, "s1"));
-        assertDoesNotThrow(() -> registry.leaveRoom("#room", null));
-        assertDoesNotThrow(() -> registry.leaveRoom(null, null));
+    void joinRoom_concurrentRoomSwitching_shouldMaintainInvariant() throws InterruptedException {
+        int iterations = 100;
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch latch = new CountDownLatch(2);
+
+        executor.submit(() -> {
+            try {
+                for (int i = 0; i < iterations; i++) {
+                    registry.joinRoom(
+                            i % 2 == 0 ? "#room1" : "#room2",
+                            "s1"
+                    );
+                }
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        executor.submit(() -> {
+            try {
+                for (int i = 0; i < iterations; i++) {
+                    Optional<String> room = registry.getRoomOfSession("s1");
+                    if (room.isPresent()) {
+                        assertTrue(
+                                registry.getRoomMembers(room.get()).contains("s1"),
+                                "Session index and room membership inconsistent"
+                        );
+                    }
+                }
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        executor.shutdown();
+
+        Optional<String> finalRoom = registry.getRoomOfSession("s1");
+        if (finalRoom.isPresent()) {
+            assertTrue(
+                    registry.getRoomMembers(finalRoom.get()).contains("s1")
+            );
+
+            String otherRoom =
+                    finalRoom.get().equals("#room1") ? "#room2" : "#room1";
+
+            assertFalse(
+                    registry.getRoomMembers(otherRoom).contains("s1")
+            );
+        }
+    }
+
+    @Test
+    void leaveRoom_concurrentLeaves_shouldHandleCorrectly() throws InterruptedException {
+        for (int i = 0; i < 10; i++) {
+            registry.joinRoom("#room", "s" + i);
+        }
+
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final String sessionId = "s" + i;
+            executor.submit(() -> {
+                try {
+                    registry.leaveRoom("#room", sessionId);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        executor.shutdown();
+
+        assertTrue(registry.getRoomMembers("#room").isEmpty());
+
+        for (int i = 0; i < threadCount; i++) {
+            assertTrue(registry.getRoomOfSession("s" + i).isEmpty());
+        }
     }
 }

--- a/src/test/java/org/example/VChatTalk/util/RoomRegistryTest.java
+++ b/src/test/java/org/example/VChatTalk/util/RoomRegistryTest.java
@@ -1,0 +1,97 @@
+package org.example.VChatTalk.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RoomRegistryTest {
+
+    private RoomRegistry roomRegistry;
+
+    @BeforeEach
+    void setUp() {
+        roomRegistry = new RoomRegistry();
+    }
+
+    @Test
+    void joinRoom_shouldAddSessionToRoom() {
+        roomRegistry.joinRoom("#room1", "s1");
+
+        Set<String> members = roomRegistry.getRoomMembers("#room1");
+
+        assertEquals(1, members.size());
+        assertTrue(members.contains("s1"));
+        assertEquals("#room1", roomRegistry.getRoomOfSession("s1").orElseThrow());
+    }
+
+    @Test
+    void joinRoom_shouldAutoLeavePreviousRoom() {
+        roomRegistry.joinRoom("#room1", "s1");
+        roomRegistry.joinRoom("#room2", "s1");
+
+        assertFalse(roomRegistry.getRoomMembers("#room1").contains("s1"));
+        assertTrue(roomRegistry.getRoomMembers("#room2").contains("s1"));
+        assertEquals("#room2", roomRegistry.getRoomOfSession("s1").orElseThrow());
+    }
+
+    @Test
+    void leaveRoom_shouldRemoveSessionAndCleanupRoom() {
+        roomRegistry.joinRoom("#room1", "s1");
+
+        roomRegistry.leaveRoom("#room1", "s1");
+
+        assertTrue(roomRegistry.getRoomMembers("#room1").isEmpty());
+        assertTrue(roomRegistry.getRoomOfSession("s1").isEmpty());
+    }
+
+    @Test
+    void leaveCurrentRoom_shouldRemoveSessionFromItsRoom() {
+        roomRegistry.joinRoom("#room1", "s1");
+
+        roomRegistry.leaveCurrentRoom("s1");
+
+        assertTrue(roomRegistry.getRoomMembers("#room1").isEmpty());
+        assertTrue(roomRegistry.getRoomOfSession("s1").isEmpty());
+    }
+
+    @Test
+    void getRoomMembers_shouldReturnUnmodifiableSet() {
+        roomRegistry.joinRoom("#room1", "s1");
+
+        Set<String> members = roomRegistry.getRoomMembers("#room1");
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> members.add("s2"));
+    }
+
+    @Test
+    void joinRoom_shouldRejectInvalidRoomId() {
+        assertThrows(IllegalArgumentException.class,
+                () -> roomRegistry.joinRoom("room1", "s1"));
+    }
+
+    @Test
+    void leaveRoom_withWrongRoomShouldNotAffectCurrentRoom() {
+        roomRegistry.joinRoom("#room1", "s1");
+
+        roomRegistry.leaveRoom("#room2", "s1");
+
+        assertEquals("#room1", roomRegistry.getRoomOfSession("s1").orElseThrow());
+        assertTrue(roomRegistry.getRoomMembers("#room1").contains("s1"));
+    }
+
+    @Test
+    void multipleSessions_shouldCoexistInSameRoom() {
+        roomRegistry.joinRoom("#room1", "s1");
+        roomRegistry.joinRoom("#room1", "s2");
+
+        Set<String> members = roomRegistry.getRoomMembers("#room1");
+
+        assertEquals(2, members.size());
+        assertTrue(members.contains("s1"));
+        assertTrue(members.contains("s2"));
+    }
+}

--- a/src/test/java/org/example/VChatTalk/util/RoomRegistryTest.java
+++ b/src/test/java/org/example/VChatTalk/util/RoomRegistryTest.java
@@ -9,89 +9,134 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class RoomRegistryTest {
 
-    private RoomRegistry roomRegistry;
+    private RoomRegistry registry;
 
     @BeforeEach
     void setUp() {
-        roomRegistry = new RoomRegistry();
+        registry = new RoomRegistry();
+    }
+
+    // ---------- joinRoom validation ----------
+
+    @Test
+    void joinRoom_withNullRoomId_shouldThrowException() {
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> registry.joinRoom(null, "s1")
+        );
+
+        assertTrue(ex.getMessage().contains("Room ID"));
     }
 
     @Test
+    void joinRoom_withEmptyRoomId_shouldThrowException() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> registry.joinRoom("", "s1")
+        );
+    }
+
+    @Test
+    void joinRoom_withHashOnlyRoomId_shouldThrowException() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> registry.joinRoom("#", "s1")
+        );
+    }
+
+    @Test
+    void joinRoom_withRoomIdWithoutHash_shouldThrowException() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> registry.joinRoom("room1", "s1")
+        );
+    }
+
+    @Test
+    void joinRoom_withNullSessionId_shouldThrowException() {
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> registry.joinRoom("#room", null)
+        );
+
+        assertTrue(ex.getMessage().contains("Session ID"));
+    }
+
+    // ---------- joinRoom behavior ----------
+
+    @Test
     void joinRoom_shouldAddSessionToRoom() {
-        roomRegistry.joinRoom("#room1", "s1");
+        registry.joinRoom("#room", "s1");
 
-        Set<String> members = roomRegistry.getRoomMembers("#room1");
-
+        Set<String> members = registry.getRoomMembers("#room");
         assertEquals(1, members.size());
         assertTrue(members.contains("s1"));
-        assertEquals("#room1", roomRegistry.getRoomOfSession("s1").orElseThrow());
+    }
+
+    @Test
+    void joinRoom_shouldAllowMultipleSessions() {
+        registry.joinRoom("#room", "s1");
+        registry.joinRoom("#room", "s2");
+
+        Set<String> members = registry.getRoomMembers("#room");
+        assertEquals(2, members.size());
+    }
+
+    @Test
+    void joinRoom_sameRoomTwice_shouldNotDuplicateSession() {
+        registry.joinRoom("#room", "s1");
+        registry.joinRoom("#room", "s1");
+
+        Set<String> members = registry.getRoomMembers("#room");
+        assertEquals(1, members.size());
     }
 
     @Test
     void joinRoom_shouldAutoLeavePreviousRoom() {
-        roomRegistry.joinRoom("#room1", "s1");
-        roomRegistry.joinRoom("#room2", "s1");
+        registry.joinRoom("#room1", "s1");
+        registry.joinRoom("#room2", "s1");
 
-        assertFalse(roomRegistry.getRoomMembers("#room1").contains("s1"));
-        assertTrue(roomRegistry.getRoomMembers("#room2").contains("s1"));
-        assertEquals("#room2", roomRegistry.getRoomOfSession("s1").orElseThrow());
+        assertFalse(registry.getRoomMembers("#room1").contains("s1"));
+        assertTrue(registry.getRoomMembers("#room2").contains("s1"));
+    }
+
+    // ---------- getRoomOfSession ----------
+
+    @Test
+    void getRoomOfSession_shouldReturnEmpty_forUnknownSession() {
+        assertTrue(registry.getRoomOfSession("unknown").isEmpty());
     }
 
     @Test
-    void leaveRoom_shouldRemoveSessionAndCleanupRoom() {
-        roomRegistry.joinRoom("#room1", "s1");
+    void getRoomOfSession_shouldReturnCurrentRoom() {
+        registry.joinRoom("#room", "s1");
 
-        roomRegistry.leaveRoom("#room1", "s1");
+        assertEquals("#room", registry.getRoomOfSession("s1").orElseThrow());
+    }
 
-        assertTrue(roomRegistry.getRoomMembers("#room1").isEmpty());
-        assertTrue(roomRegistry.getRoomOfSession("s1").isEmpty());
+    // ---------- leaveRoom ----------
+
+    @Test
+    void leaveRoom_shouldRemoveSession() {
+        registry.joinRoom("#room", "s1");
+        registry.leaveRoom("#room", "s1");
+
+        assertTrue(registry.getRoomMembers("#room").isEmpty());
+        assertTrue(registry.getRoomOfSession("s1").isEmpty());
     }
 
     @Test
-    void leaveCurrentRoom_shouldRemoveSessionFromItsRoom() {
-        roomRegistry.joinRoom("#room1", "s1");
+    void leaveRoom_withWrongRoom_shouldDoNothing() {
+        registry.joinRoom("#room1", "s1");
+        registry.leaveRoom("#room2", "s1");
 
-        roomRegistry.leaveCurrentRoom("s1");
-
-        assertTrue(roomRegistry.getRoomMembers("#room1").isEmpty());
-        assertTrue(roomRegistry.getRoomOfSession("s1").isEmpty());
+        assertTrue(registry.getRoomMembers("#room1").contains("s1"));
     }
 
     @Test
-    void getRoomMembers_shouldReturnUnmodifiableSet() {
-        roomRegistry.joinRoom("#room1", "s1");
-
-        Set<String> members = roomRegistry.getRoomMembers("#room1");
-
-        assertThrows(UnsupportedOperationException.class,
-                () -> members.add("s2"));
-    }
-
-    @Test
-    void joinRoom_shouldRejectInvalidRoomId() {
-        assertThrows(IllegalArgumentException.class,
-                () -> roomRegistry.joinRoom("room1", "s1"));
-    }
-
-    @Test
-    void leaveRoom_withWrongRoomShouldNotAffectCurrentRoom() {
-        roomRegistry.joinRoom("#room1", "s1");
-
-        roomRegistry.leaveRoom("#room2", "s1");
-
-        assertEquals("#room1", roomRegistry.getRoomOfSession("s1").orElseThrow());
-        assertTrue(roomRegistry.getRoomMembers("#room1").contains("s1"));
-    }
-
-    @Test
-    void multipleSessions_shouldCoexistInSameRoom() {
-        roomRegistry.joinRoom("#room1", "s1");
-        roomRegistry.joinRoom("#room1", "s2");
-
-        Set<String> members = roomRegistry.getRoomMembers("#room1");
-
-        assertEquals(2, members.size());
-        assertTrue(members.contains("s1"));
-        assertTrue(members.contains("s2"));
+    void leaveRoom_withNullArguments_shouldDoNothing() {
+        assertDoesNotThrow(() -> registry.leaveRoom(null, "s1"));
+        assertDoesNotThrow(() -> registry.leaveRoom("#room", null));
+        assertDoesNotThrow(() -> registry.leaveRoom(null, null));
     }
 }


### PR DESCRIPTION
feat(core): add RoomRegistry with invariant enforcement and unit tests

Introduce RoomRegistry as a thread-safe component to manage chat room
lifecycles and session memberships.

- Enforce single-room-per-session invariant via session-to-room index
- Use ConcurrentHashMap and newKeySet for concurrency safety
- Automatically create rooms on join and remove empty rooms on leave
- Provide reverse lookup for session-to-room resolution
- Add unit tests covering room lifecycle and core invariants
