### PR TITLE
US-6.2 Feature/Implement ChatContext Strategy (Refactor State)

### DIFF
--- a/src/main/java/org/example/VChatTalk/command/impl/LeaveCommand.java
+++ b/src/main/java/org/example/VChatTalk/command/impl/LeaveCommand.java
@@ -1,9 +1,12 @@
 package org.example.VChatTalk.command.impl;
 
+import lombok.RequiredArgsConstructor;
 import org.example.VChatTalk.command.CommandResult;
 import org.example.VChatTalk.command.CommandType;
 import org.example.VChatTalk.command.IChatCommand;
 import org.example.VChatTalk.command.MessageConstants;
+import org.example.VChatTalk.model.ChatContext;
+import org.example.VChatTalk.model.UserSession;
 import org.example.VChatTalk.util.PrivateChatRegistry;
 import org.example.VChatTalk.util.SystemResponseSender;
 import org.example.VChatTalk.util.UserRegistry;
@@ -13,36 +16,50 @@ import org.springframework.web.socket.WebSocketSession;
 import java.io.IOException;
 
 @Component
+@RequiredArgsConstructor
 public class LeaveCommand implements IChatCommand {
     private final UserRegistry userRegistry;
     private final SystemResponseSender responder;
     private final PrivateChatRegistry privateChatRegistry;
-
-    public LeaveCommand(UserRegistry userRegistry, SystemResponseSender responder, PrivateChatRegistry privateChatRegistry) {
-        this.userRegistry = userRegistry;
-        this.responder = responder;
-        this.privateChatRegistry = privateChatRegistry;
-    }
 
     @Override
     public CommandType getType() {
         return CommandType.LEAVE;
     }
 
+    /**
+     * Helper method to reset user state to GLOBAL
+     */
+    private void updateToGlobal(UserSession currentSession) {
+        UserSession globalSession = currentSession.withContext(ChatContext.GLOBAL);
+        userRegistry.updateUser(globalSession);
+    }
+
     @Override
     public void execute(WebSocketSession session, CommandResult result) throws IOException {
-        if (!userRegistry.isUserRegistered(session.getId())) {
+        String sessionId = session.getId();
+        UserSession userSession = userRegistry.getSession(sessionId);
+
+        // Auth Check
+        if (userSession == null || MessageConstants.USER_ANONYMOUS.equals(userSession.getUsername())) {
             responder.sendError(session, MessageConstants.ERR_NOT_LOGGED_IN);
             return;
         }
 
-        String currentTarget = privateChatRegistry.getTarget(session.getId());
+        ChatContext currentContext = userSession.getContext();
 
-        if (currentTarget != null) {
-            privateChatRegistry.removeTarget(session.getId());
+        // Handle PRIVATE Context
+        if (currentContext == ChatContext.PRIVATE) {
+            privateChatRegistry.removeTarget(sessionId);
+
+            // Switch state back to GLOBAL
+            updateToGlobal(userSession);
+
             responder.sendSystem(session, MessageConstants.MSG_PRIVATE_CHAT_LEAVE);
-        } else {
-            responder.sendSystem(session, MessageConstants.ERR_ALREADY_IN_GLOBAL);
+            return;
         }
+
+        // Already GLOBAL
+        responder.sendError(session, MessageConstants.ERR_ALREADY_IN_GLOBAL);
     }
 }

--- a/src/main/java/org/example/VChatTalk/command/impl/LeaveCommand.java
+++ b/src/main/java/org/example/VChatTalk/command/impl/LeaveCommand.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 @Component
 @RequiredArgsConstructor
 public class LeaveCommand implements IChatCommand {
+
     private final UserRegistry userRegistry;
     private final SystemResponseSender responder;
     private final PrivateChatRegistry privateChatRegistry;
@@ -27,39 +28,31 @@ public class LeaveCommand implements IChatCommand {
         return CommandType.LEAVE;
     }
 
-    /**
-     * Helper method to reset user state to GLOBAL
-     */
-    private void updateToGlobal(UserSession currentSession) {
-        UserSession globalSession = currentSession.withContext(ChatContext.GLOBAL);
-        userRegistry.updateUser(globalSession);
-    }
-
     @Override
     public void execute(WebSocketSession session, CommandResult result) throws IOException {
         String sessionId = session.getId();
         UserSession userSession = userRegistry.getSession(sessionId);
 
-        // Auth Check
-        if (userSession == null || MessageConstants.USER_ANONYMOUS.equals(userSession.getUsername())) {
+        // 1️⃣ Auth check
+        if (userSession == null ||
+                MessageConstants.USER_ANONYMOUS.equals(userSession.getUsername())) {
             responder.sendError(session, MessageConstants.ERR_NOT_LOGGED_IN);
             return;
         }
 
-        ChatContext currentContext = userSession.getContext();
-
-        // Handle PRIVATE Context
-        if (currentContext == ChatContext.PRIVATE) {
+        // 2️⃣ Context handling
+        if (userSession.getContext() == ChatContext.PRIVATE) {
+            // Clean private chat state
             privateChatRegistry.removeTarget(sessionId);
 
-            // Switch state back to GLOBAL
-            updateToGlobal(userSession);
+            // Switch back to GLOBAL
+            userRegistry.updateContext(sessionId, ChatContext.GLOBAL);
 
             responder.sendSystem(session, MessageConstants.MSG_PRIVATE_CHAT_LEAVE);
             return;
         }
 
-        // Already GLOBAL
+        // 3️⃣ Already GLOBAL
         responder.sendError(session, MessageConstants.ERR_ALREADY_IN_GLOBAL);
     }
 }

--- a/src/main/java/org/example/VChatTalk/command/impl/SelectCommand.java
+++ b/src/main/java/org/example/VChatTalk/command/impl/SelectCommand.java
@@ -1,9 +1,12 @@
 package org.example.VChatTalk.command.impl;
 
+import lombok.RequiredArgsConstructor;
 import org.example.VChatTalk.command.CommandResult;
 import org.example.VChatTalk.command.CommandType;
 import org.example.VChatTalk.command.IChatCommand;
 import org.example.VChatTalk.command.MessageConstants;
+import org.example.VChatTalk.model.ChatContext;
+import org.example.VChatTalk.model.UserSession;
 import org.example.VChatTalk.util.PrivateChatRegistry;
 import org.example.VChatTalk.util.SystemResponseSender;
 import org.example.VChatTalk.util.UserRegistry;
@@ -13,17 +16,11 @@ import org.springframework.web.socket.WebSocketSession;
 import java.io.IOException;
 
 @Component
+@RequiredArgsConstructor
 public class SelectCommand implements IChatCommand {
     private final SystemResponseSender responder;
     private final UserRegistry userRegistry;
     private final PrivateChatRegistry privateChatRegistry;
-
-
-    public SelectCommand(UserRegistry userRegistry, SystemResponseSender responder, PrivateChatRegistry privateChatRegistry) {
-        this.userRegistry = userRegistry;
-        this.responder = responder;
-        this.privateChatRegistry = privateChatRegistry;
-    }
 
     @Override
     public CommandType getType() {
@@ -32,8 +29,11 @@ public class SelectCommand implements IChatCommand {
 
     @Override
     public void execute(WebSocketSession session, CommandResult result) throws IOException {
+        String sessionId = session.getId();
+        UserSession userSession = userRegistry.getSession(sessionId);
+
         // Auth Check
-        if (!userRegistry.isUserRegistered(session.getId())) {
+        if (userSession == null || MessageConstants.USER_ANONYMOUS.equals(userSession.getUsername())) {
             responder.sendError(session, MessageConstants.ERR_NOT_LOGGED_IN);
             return;
         }
@@ -52,7 +52,7 @@ public class SelectCommand implements IChatCommand {
         }
 
         // Self Chat Check
-        String currentUser = userRegistry.getUsername(session.getId());
+        String currentUser = userSession.getUsername();
         if (targetUser.equals(currentUser)) {
             responder.sendError(session, MessageConstants.ERR_SELF_CHAT);
             return;
@@ -61,6 +61,10 @@ public class SelectCommand implements IChatCommand {
         // Online Check & Switch
         if (userRegistry.isUserOnline(targetUser)) {
             privateChatRegistry.setTarget(session.getId(), targetUser);
+            // Update "State" (UserSession Context)
+            UserSession newSession = userSession.withContext(ChatContext.PRIVATE);
+            userRegistry.updateUser(newSession);
+
             responder.sendSystem(session, String.format(MessageConstants.MSG_PRIVATE_CHAT_START, targetUser));
         } else {
             responder.sendError(session, String.format(MessageConstants.ERR_USER_OFFLINE, targetUser));

--- a/src/main/java/org/example/VChatTalk/command/impl/SelectCommand.java
+++ b/src/main/java/org/example/VChatTalk/command/impl/SelectCommand.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 @Component
 @RequiredArgsConstructor
 public class SelectCommand implements IChatCommand {
+
     private final SystemResponseSender responder;
     private final UserRegistry userRegistry;
     private final PrivateChatRegistry privateChatRegistry;
@@ -32,42 +33,46 @@ public class SelectCommand implements IChatCommand {
         String sessionId = session.getId();
         UserSession userSession = userRegistry.getSession(sessionId);
 
-        // Auth Check
-        if (userSession == null || MessageConstants.USER_ANONYMOUS.equals(userSession.getUsername())) {
+        // 1️⃣ Auth check
+        if (userSession == null ||
+                MessageConstants.USER_ANONYMOUS.equals(userSession.getUsername())) {
             responder.sendError(session, MessageConstants.ERR_NOT_LOGGED_IN);
             return;
         }
 
-        // Arg Check
+        // 2️⃣ Arg check
         String targetUser = result.getArgument();
         if (targetUser == null || targetUser.isBlank()) {
-            responder.sendError(session, String.format(MessageConstants.ERR_MISSING_ARG_USER, "/select"));
+            responder.sendError(session,
+                    String.format(MessageConstants.ERR_MISSING_ARG_USER, "/select"));
             return;
         }
 
-        // Username cannot contain spaces
+        // 3️⃣ Username format
         if (targetUser.trim().contains(" ")) {
             responder.sendError(session, MessageConstants.ERR_USERNAME_CONTAIN_SPACE);
             return;
         }
 
-        // Self Chat Check
+        // 4️⃣ Self chat
         String currentUser = userSession.getUsername();
         if (targetUser.equals(currentUser)) {
             responder.sendError(session, MessageConstants.ERR_SELF_CHAT);
             return;
         }
 
-        // Online Check & Switch
-        if (userRegistry.isUserOnline(targetUser)) {
-            privateChatRegistry.setTarget(session.getId(), targetUser);
-            // Update "State" (UserSession Context)
-            UserSession newSession = userSession.withContext(ChatContext.PRIVATE);
-            userRegistry.updateUser(newSession);
-
-            responder.sendSystem(session, String.format(MessageConstants.MSG_PRIVATE_CHAT_START, targetUser));
-        } else {
-            responder.sendError(session, String.format(MessageConstants.ERR_USER_OFFLINE, targetUser));
+        // 5️⃣ Online check & switch
+        if (!userRegistry.isUserOnline(targetUser)) {
+            responder.sendError(session,
+                    String.format(MessageConstants.ERR_USER_OFFLINE, targetUser));
+            return;
         }
+
+        // 6️⃣ State transition
+        privateChatRegistry.setTarget(sessionId, targetUser);
+        userRegistry.updateContext(sessionId, ChatContext.PRIVATE);
+
+        responder.sendSystem(session,
+                String.format(MessageConstants.MSG_PRIVATE_CHAT_START, targetUser));
     }
 }

--- a/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
+++ b/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
@@ -26,22 +26,24 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
     private final SessionRegistry sessionRegistry;
     private final UserRegistry userRegistry;
     private final PrivateChatRegistry privateChatRegistry;
+    // private final RoomRegistry roomRegistry; // 🟡 TODO: Uncomment when RoomRegistry is ready
     private final ChatService chatService;
     private final MessageProcessor messageProcessor;
     private final BroadcastService broadcastService;
     private final RateLimiter rateLimiter;
     private final SystemResponseSender systemResponseSender;
 
-    /**
-     * ========== CONNECTION LIFECYCLE ==========
-     */
 
+    // ========== CONNECTION LIFECYCLE ==========
     /**
      * Called when new WebSocket connection is established
      */
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         sessionRegistry.addSession(session);
+
+        userRegistry.addSession(session.getId());
+
         systemResponseSender.sendSystem(session, MessageConstants.MSG_WELCOME);
 
         log.info("[CONNECT] Session: {}", session.getId());
@@ -63,12 +65,20 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
             notifyFollowersOfDisconnect(username);
         }
 
-        // Clean up all registries
-        rateLimiter.removeSession(sessionId);
-        sessionRegistry.removeSession(sessionId);
+        // 2. Leave Room (Pending)
+        // 🟡 TODO: Uncomment this when RoomRegistry is implemented
+        // if (roomRegistry != null) {
+        //     roomRegistry.leaveCurrentRoom(sessionId);
+        // }
 
         // Handle leave and broadcast to all users
         MessageDTO leaveMessage = chatService.handleLeave(sessionId);
+
+        // Clean up all registries
+        rateLimiter.removeSession(sessionId);
+        sessionRegistry.removeSession(sessionId);
+        userRegistry.removeUser(sessionId);
+
         if (leaveMessage != null) {
             broadcastService.broadcast(leaveMessage, null);
         }
@@ -78,10 +88,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         userRegistry.logCountOnlineUsers();
     }
 
-    /**
-     * ========== MESSAGE HANDLING ==========
-     */
-
+    // ========== MESSAGE HANDLING ==========
     /**
      * Called when text message is received from WebSocket
      */
@@ -97,10 +104,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         messageProcessor.processMessage(session, message.getPayload());
     }
 
-    /**
-     * ========== HELPER METHODS ==========
-     */
-
+    // ========== HELPER METHODS ==========
     /**
      * Notify all users who were targeting the disconnected user
      * Remove their targets and send notification

--- a/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
+++ b/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
@@ -14,6 +14,8 @@ import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
+import java.util.Set;
+
 /**
  * WebSocket handler for chat functionality
  * Manages connection lifecycle and delegates message processing
@@ -62,12 +64,10 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
 
         // Notify followers if user was registered (not Anonymous)
         if (!MessageConstants.USER_ANONYMOUS.equals(username)) {
-            notifyFollowersOfDisconnect(username);
+            notifyFollowersOfDisconnect(session, username);
         }
 
-         if (roomRegistry != null) {
-             roomRegistry.leaveCurrentRoom(sessionId);
-         }
+//        roomRegistry.leaveCurrentRoom(sessionId);
 
         // Handle leave and broadcast to all users
         MessageDTO leaveMessage = chatService.handleLeave(sessionId);
@@ -107,23 +107,46 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
      * Notify all users who were targeting the disconnected user
      * Remove their targets and send notification
      */
-    private void notifyFollowersOfDisconnect(String username) {
-        privateChatRegistry.getSessionsTargeting(username).forEach(followerSessionId -> {
+    private void notifyFollowersOfDisconnect(WebSocketSession disconnectedSession, String username) {
+        if (username == null) {
+            return;
+        }
+
+        Set<String> followerSessionIds =
+                privateChatRegistry.getSessionsTargeting(username);
+
+        if (followerSessionIds.isEmpty()) {
+            log.debug("notifyFollowersOfDisconnect failed: followerSessionIds is empty");
+            return;
+        }
+
+        for (String followerSessionId : followerSessionIds) {
+            privateChatRegistry.removeTarget(followerSessionId);
+
             WebSocketSession followerSession = sessionRegistry.findSessionById(followerSessionId);
 
-            if (followerSession != null && followerSession.isOpen()) {
-                try {
-                    // Remove target and return to global mode
-                    privateChatRegistry.removeTarget(followerSessionId);
-
-                    systemResponseSender.sendSystem(
-                            followerSession,
-                            String.format(MessageConstants.MSG_DISCONNECT_NOTIFY, username)
-                    );
-                } catch (Exception e) {
-                    log.error("Error notifying follower {}: {}", followerSessionId, e.getMessage());
-                }
+            if (followerSession == null || !followerSession.isOpen()) {
+                continue;
             }
-        });
+
+            try {
+                systemResponseSender.sendSystem(
+                        followerSession,
+                        String.format(
+                                MessageConstants.MSG_DISCONNECT_NOTIFY,
+                                username
+                        )
+                );
+            } catch (Exception ex) {
+                log.warn(
+                        "[DISCONNECT_NOTIFY_FAILED] followerSession={}, username={}",
+                        followerSessionId,
+                        username,
+                        ex
+                );
+            } finally {
+                privateChatRegistry.removeTarget(disconnectedSession.getId());
+            }
+        }
     }
 }

--- a/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
+++ b/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
@@ -26,7 +26,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
     private final SessionRegistry sessionRegistry;
     private final UserRegistry userRegistry;
     private final PrivateChatRegistry privateChatRegistry;
-    // private final RoomRegistry roomRegistry; // 🟡 TODO: Uncomment when RoomRegistry is ready
+    private final RoomRegistry roomRegistry;
     private final ChatService chatService;
     private final MessageProcessor messageProcessor;
     private final BroadcastService broadcastService;
@@ -65,11 +65,9 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
             notifyFollowersOfDisconnect(username);
         }
 
-        // 2. Leave Room (Pending)
-        // 🟡 TODO: Uncomment this when RoomRegistry is implemented
-        // if (roomRegistry != null) {
-        //     roomRegistry.leaveCurrentRoom(sessionId);
-        // }
+         if (roomRegistry != null) {
+             roomRegistry.leaveCurrentRoom(sessionId);
+         }
 
         // Handle leave and broadcast to all users
         MessageDTO leaveMessage = chatService.handleLeave(sessionId);

--- a/src/main/java/org/example/VChatTalk/model/ChatContext.java
+++ b/src/main/java/org/example/VChatTalk/model/ChatContext.java
@@ -1,0 +1,7 @@
+package org.example.VChatTalk.model;
+
+public enum ChatContext {
+    GLOBAL,
+    PRIVATE,
+    ROOM
+}

--- a/src/main/java/org/example/VChatTalk/model/UserSession.java
+++ b/src/main/java/org/example/VChatTalk/model/UserSession.java
@@ -3,9 +3,9 @@ package org.example.VChatTalk.model;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.With;
+import org.example.VChatTalk.command.MessageConstants;
 
 import java.util.Objects;
-
 
 @Getter
 @Builder(toBuilder = true)
@@ -25,15 +25,19 @@ public class UserSession {
     public static UserSession create(String sessionId) {
         return UserSession.builder()
                 .sessionId(sessionId)
-                .username("Anonymous")
+                .username(MessageConstants.USER_ANONYMOUS)
                 .context(ChatContext.GLOBAL)
                 .build();
     }
 
     @Override
     public boolean equals(Object o) {
-        if(this == o) return true;
-        if(!(o instanceof UserSession)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof UserSession)) {
+            return false;
+        }
         return Objects.equals(this.sessionId, ((UserSession) o).sessionId);
     }
 

--- a/src/main/java/org/example/VChatTalk/model/UserSession.java
+++ b/src/main/java/org/example/VChatTalk/model/UserSession.java
@@ -3,29 +3,38 @@ package org.example.VChatTalk.model;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.With;
-import org.springframework.web.socket.WebSocketSession;
 
 import java.util.Objects;
 
 
 @Getter
-@Builder
+@Builder(toBuilder = true)
 public class UserSession {
     private final String sessionId;
+
     @With
     private final String username;
-    @With
-    private final String targetUser;
-    private final WebSocketSession session;
-    @With
-    private final String currentRoomId;
 
+    @With
+    private final ChatContext context;
+
+    /**
+     * Factory method to create a fresh anonymous session.
+     * Default context is GLOBAL.
+     */
+    public static UserSession create(String sessionId) {
+        return UserSession.builder()
+                .sessionId(sessionId)
+                .username("Anonymous")
+                .context(ChatContext.GLOBAL)
+                .build();
+    }
 
     @Override
     public boolean equals(Object o) {
         if(this == o) return true;
         if(!(o instanceof UserSession)) return false;
-        return Objects.equals(this.sessionId, ((UserSession) o).sessionId); // fixed it
+        return Objects.equals(this.sessionId, ((UserSession) o).sessionId);
     }
 
     @Override

--- a/src/main/java/org/example/VChatTalk/service/ChatService.java
+++ b/src/main/java/org/example/VChatTalk/service/ChatService.java
@@ -2,8 +2,11 @@
 
     import lombok.RequiredArgsConstructor;
     import lombok.extern.slf4j.Slf4j;
+    import org.example.VChatTalk.command.MessageConstants;
+    import org.example.VChatTalk.model.ChatContext;
     import org.example.VChatTalk.model.MessageDTO;
     import org.example.VChatTalk.model.MessageType;
+    import org.example.VChatTalk.model.UserSession;
     import org.example.VChatTalk.util.AnsiColor;
     import org.example.VChatTalk.util.PrivateChatRegistry;
     import org.example.VChatTalk.util.SessionRegistry;
@@ -35,16 +38,32 @@
          */
         public void routeMessage(WebSocketSession senderSession, MessageDTO dto) throws IOException {
             String sessionId = senderSession.getId();
-            MessageDTO baseMessage = handleMessage(sessionId, dto);
 
-            String targetUsername = privateChatRegistry.getTarget(sessionId);
+            // Auth Check (Get Logical Session)
+            UserSession userSession = userRegistry.getSession(sessionId);
+            if (userSession == null || MessageConstants.USER_ANONYMOUS.equals(userSession.getUsername())) {
+                throw new IllegalStateException("Please login before chatting.");
+            }
 
-            if (targetUsername != null) {
-                // PRIVATE CHAT MODE
-                handlePrivateMessage(senderSession, baseMessage, targetUsername);
-            } else {
-                // GLOBAL CHAT MODE - broadcast to all
-                broadcastService.broadcast(baseMessage, senderSession);
+            // Prepare Base Message
+            MessageDTO message = handleMessage(sessionId, dto);
+
+            // Route based on Context
+            ChatContext context = userSession.getContext();
+
+            switch (context) {
+                case PRIVATE -> {
+                    String targetUser = privateChatRegistry.getTarget(sessionId);
+                    if (targetUser != null) {
+                        handlePrivateMessage(senderSession, message, targetUser);
+                    } else {
+                        // Fallback error if state is inconsistent
+                        broadcastService.sendToSession(senderSession,
+                                systemMessage(AnsiColor.RED + "Error: Private chat target lost." + AnsiColor.RESET));
+                    }
+                }
+                case ROOM -> handleRoomMessage(senderSession, message);
+                case GLOBAL -> broadcastService.broadcast(message, senderSession);
             }
         }
 
@@ -91,8 +110,6 @@
             }
 
             String username = userRegistry.getUsername(sessionId);
-            userRegistry.removeUser(sessionId);
-            privateChatRegistry.removeTarget(sessionId);
 
             int count = userRegistry.countOnlineUsers();
             return systemMessage(username + " has left the chat. (Total: " + count + ")");
@@ -161,6 +178,13 @@
             broadcastService.sendToSession(sender, selfEcho);
 
             log.info("[PRIVATE_MSG] {} → {}: {}", message.getSender(), targetUsername, message.getContent());
+        }
+
+        /**
+         * Handles broadcasting a message to a specific room.
+         */
+        private void handleRoomMessage(WebSocketSession senderSession, MessageDTO message) throws IOException {
+            // 🟡 TODO: Update and Uncomment when RoomRegistry is ready
         }
 
         /**

--- a/src/main/java/org/example/VChatTalk/service/ChatService.java
+++ b/src/main/java/org/example/VChatTalk/service/ChatService.java
@@ -111,7 +111,7 @@
 
             String username = userRegistry.getUsername(sessionId);
 
-            int count = userRegistry.countOnlineUsers();
+            int count = Math.max(0, userRegistry.countOnlineUsers() - 1);
             return systemMessage(username + " has left the chat. (Total: " + count + ")");
         }
 

--- a/src/main/java/org/example/VChatTalk/service/ChatService.java
+++ b/src/main/java/org/example/VChatTalk/service/ChatService.java
@@ -2,7 +2,6 @@
 
     import lombok.RequiredArgsConstructor;
     import lombok.extern.slf4j.Slf4j;
-    import org.example.VChatTalk.command.MessageConstants;
     import org.example.VChatTalk.model.ChatContext;
     import org.example.VChatTalk.model.MessageDTO;
     import org.example.VChatTalk.model.MessageType;
@@ -32,7 +31,21 @@
         private final BroadcastService broadcastService;
 
         // ========== MESSAGE ROUTING ==========
+        private void recoverFromBrokenPrivateContext(WebSocketSession session, String sessionId)
+                throws IOException {
 
+            log.warn("Broken PRIVATE context for session {}. Resetting to GLOBAL.", sessionId);
+
+            privateChatRegistry.removeTarget(sessionId);
+            userRegistry.updateContext(sessionId, ChatContext.GLOBAL);
+
+            broadcastService.sendToSession(
+                    session,
+                    systemMessage(AnsiColor.RED +
+                            "Private chat target lost. Returned to global chat." +
+                            AnsiColor.RESET)
+            );
+        }
         /**
          * Route message to either global chat or private chat based on user's target
          */
@@ -40,26 +53,27 @@
             String sessionId = senderSession.getId();
 
             // Auth Check (Get Logical Session)
-            UserSession userSession = userRegistry.getSession(sessionId);
-            if (userSession == null || MessageConstants.USER_ANONYMOUS.equals(userSession.getUsername())) {
+            if (!userRegistry.isUserRegistered(sessionId)) {
                 throw new IllegalStateException("Please login before chatting.");
             }
 
             // Prepare Base Message
             MessageDTO message = handleMessage(sessionId, dto);
 
-            // Route based on Context
-            ChatContext context = userSession.getContext();
+            UserSession sender = userRegistry.getSession(sessionId);
+            if (sender == null) {
+                log.debug("route failed: sender is null");
+                return;
+            }
 
-            switch (context) {
+            // Route based on Context
+            switch (sender.getContext()) {
                 case PRIVATE -> {
                     String targetUser = privateChatRegistry.getTarget(sessionId);
                     if (targetUser != null) {
                         handlePrivateMessage(senderSession, message, targetUser);
                     } else {
-                        // Fallback error if state is inconsistent
-                        broadcastService.sendToSession(senderSession,
-                                systemMessage(AnsiColor.RED + "Error: Private chat target lost." + AnsiColor.RESET));
+                        recoverFromBrokenPrivateContext(senderSession, sessionId);
                     }
                 }
                 case ROOM -> handleRoomMessage(senderSession, message);
@@ -94,6 +108,8 @@
             boolean success = userRegistry.tryRegisterUser(sessionId, name);
             if (!success) {
                 throw new IllegalArgumentException("Username '" + name + "' is already taken. Please choose another.");
+            } else {
+                userRegistry.updateContext(sessionId, ChatContext.GLOBAL);
             }
 
             int count = userRegistry.countOnlineUsers();

--- a/src/main/java/org/example/VChatTalk/util/PrivateChatRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/PrivateChatRegistry.java
@@ -80,6 +80,10 @@ public class PrivateChatRegistry {
         }
     }
 
+    /**
+     * Returns all sessionIds that are currently targeting the given username.
+     * No ordering is guaranteed. The returned set is unmodifiable.
+     */
     public Set<String> getSessionsTargeting(String targetUsername) {
         if (targetUsername == null) {
             return Collections.emptySet();

--- a/src/main/java/org/example/VChatTalk/util/PrivateChatRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/PrivateChatRegistry.java
@@ -1,45 +1,95 @@
 package org.example.VChatTalk.util;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Registry for Private Chat connections.
+ * Stores "Who is talking to whom".
+ * <p>
+ * Optimized with Reverse Index for O(1) lookup on disconnects.
+ */
+@Slf4j
 @Component
 public class PrivateChatRegistry {
 
     // key = sessionId (who is targeting), value = targetUsername (who is being targeted)
     private final ConcurrentHashMap<String, String> sessionTargets = new ConcurrentHashMap<>();
 
+    // Reverse Index: Target Username -> Set of SessionIDs (Senders)
+    // Used for O(1) notification when a target user disconnects
+    private final ConcurrentHashMap<String, Set<String>> targetToSenders = new ConcurrentHashMap<>();
+
     public void setTarget(String sessionId, String targetUsername) {
-        if (sessionId != null && targetUsername != null) {
-            sessionTargets.put(sessionId, targetUsername);
+        if (sessionId == null || targetUsername == null) {
+            log.debug("setTarget failed: null params");
+            return;
         }
+
+        // Remove old target if exists
+        removeTarget(sessionId);
+
+        // Add new mapping
+        sessionTargets.put(sessionId, targetUsername);
+
+        // Update Reverse Index
+        targetToSenders.computeIfAbsent(targetUsername, k -> ConcurrentHashMap.newKeySet()).add(sessionId);
+
+        log.debug("Session [{}] is now targeting user [{}]", sessionId, targetUsername);
     }
 
+    /**
+     * Get the username that this session is currently targeting.
+     */
     public String getTarget(String sessionId) {
-        if (sessionId == null) return null;
+        if (sessionId == null) {
+            log.debug("getTarget failed: sessionId is null");
+            return null;
+        }
+
         return sessionTargets.get(sessionId);
     }
 
+    /**
+     * Removes the private chat target for a session (Switching to Global/Room).
+     */
     public void removeTarget(String sessionId) {
-        if (sessionId != null) {
-            sessionTargets.remove(sessionId);
+        if (sessionId == null) {
+            log.debug("removeTarget failed: sessionId is null");
+            return;
+        }
+
+        // Get current target to clean up reverse index
+        String oldTarget = sessionTargets.remove(sessionId);
+
+        if (oldTarget != null) {
+            // Remove from Reverse Index
+            Set<String> senders = targetToSenders.get(oldTarget);
+            if (senders != null) {
+                senders.remove(sessionId);
+                // Clean up empty sets to prevent memory leaks
+                if (senders.isEmpty()) {
+                    targetToSenders.remove(oldTarget);
+                }
+            }
+            log.debug("Session [{}] stopped targeting user [{}]", sessionId, oldTarget);
         }
     }
 
-    public List<String> getSessionsTargeting(String targetUsername) {
-        if (targetUsername == null) return Collections.emptyList();
+    public Set<String> getSessionsTargeting(String targetUsername) {
+        if (targetUsername == null) {
+            return Collections.emptySet();
+        }
 
-        List<String> targetingSessions = new ArrayList<>();
-        sessionTargets.forEach((sessionId, target) -> {
-            if (target.equals(targetUsername)) {
-                targetingSessions.add(sessionId);
-            }
-        });
-
-        return Collections.unmodifiableList(targetingSessions);
+        Set<String> targetingSessions = targetToSenders.get(targetUsername);
+        if (targetingSessions == null) {
+            return Collections.emptySet();
+        }
+        // Return unmodifiable to protect the registry
+        return Collections.unmodifiableSet(targetingSessions);
     }
 }

--- a/src/main/java/org/example/VChatTalk/util/UserRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/UserRegistry.java
@@ -1,6 +1,7 @@
 package org.example.VChatTalk.util;
 
 import org.example.VChatTalk.command.MessageConstants;
+import org.example.VChatTalk.model.ChatContext;
 import org.example.VChatTalk.model.UserSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,7 +16,7 @@ public class UserRegistry {
     private static final Logger logger = LoggerFactory.getLogger(UserRegistry.class);
 
     // Primary Store: SessionID -> UserSession (State)
-    private final ConcurrentHashMap<String, UserSession> sessionUsernames = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, UserSession> sessionStates = new ConcurrentHashMap<>();
 
     // Secondary Index: Username -> SessionID (Lookup)
     private final ConcurrentHashMap<String, String> usernameSessions = new ConcurrentHashMap<>();
@@ -29,7 +30,8 @@ public class UserRegistry {
             logger.debug("UserRegistry addSession failed: sessionId is null.");
             return;
         }
-        sessionUsernames.put(sessionId, UserSession.create(sessionId));
+        removeUser(sessionId);
+        sessionStates.put(sessionId, UserSession.create(sessionId));
     }
 
     /**
@@ -50,7 +52,7 @@ public class UserRegistry {
             return false;
         }
         // Update UserSession State
-        UserSession updated = sessionUsernames.computeIfPresent(sessionId, (id, userSession) ->
+        UserSession updated = sessionStates.computeIfPresent(sessionId, (id, userSession) ->
                 userSession.withUsername(username)
         );
 
@@ -63,13 +65,12 @@ public class UserRegistry {
         return true;
     }
 
-    /**
-     * Update the entire session state (e.g. changing Context).
-     */
-    public void updateUser(UserSession session) {
-        if (session != null) {
-            sessionUsernames.put(session.getSessionId(), session);
-        }
+    public void updateContext(String sessionId, ChatContext newContext) {
+        if (sessionId == null || newContext == null) return;
+
+        sessionStates.computeIfPresent(sessionId,
+                (id, userSession) -> userSession.withContext(newContext)
+        );
     }
 
     /**
@@ -81,7 +82,7 @@ public class UserRegistry {
             return;
         }
 
-        UserSession removed = sessionUsernames.remove(sessionId);
+        UserSession removed = sessionStates.remove(sessionId);
 
         if (removed != null && !MessageConstants.USER_ANONYMOUS.equals(removed.getUsername())) {
             usernameSessions.remove(removed.getUsername());
@@ -92,16 +93,16 @@ public class UserRegistry {
     // ========== LOOKUP METHODS ==========
 
     public UserSession getSession(String sessionId) {
-        return sessionUsernames.get(sessionId);
+        return sessionStates.get(sessionId);
     }
 
     public String getUsername(String sessionId) {
-        UserSession session = sessionUsernames.get(sessionId);
+        UserSession session = sessionStates.get(sessionId);
         return (session != null) ? session.getUsername() : MessageConstants.USER_ANONYMOUS;
     }
 
     public boolean isUserRegistered(String sessionId) {
-        UserSession session = sessionUsernames.get(sessionId);
+        UserSession session = sessionStates.get(sessionId);
         return session != null && !MessageConstants.USER_ANONYMOUS.equals(session.getUsername());
     }
 
@@ -127,7 +128,7 @@ public class UserRegistry {
     }
 
     public void logCountOnlineUsers() {
-        int count = Math.max(0, countOnlineUsers() - 1);
+        int count = countOnlineUsers();
         logger.info("All online connections: {}", count);
     }
 }

--- a/src/main/java/org/example/VChatTalk/util/UserRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/UserRegistry.java
@@ -40,6 +40,10 @@ public class UserRegistry {
             return false;
         }
 
+        if (isUserRegistered(sessionId)) {
+            return false;
+        }
+
         // Check if username taken
         String existingSession = usernameSessions.putIfAbsent(username, sessionId);
         if (existingSession != null) {

--- a/src/main/java/org/example/VChatTalk/util/UserRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/UserRegistry.java
@@ -1,5 +1,7 @@
 package org.example.VChatTalk.util;
 
+import org.example.VChatTalk.command.MessageConstants;
+import org.example.VChatTalk.model.UserSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -12,18 +14,44 @@ import java.util.concurrent.ConcurrentHashMap;
 public class UserRegistry {
     private static final Logger logger = LoggerFactory.getLogger(UserRegistry.class);
 
-    private final ConcurrentHashMap<String, String> sessionUsernames = new ConcurrentHashMap<>();
+    // Primary Store: SessionID -> UserSession (State)
+    private final ConcurrentHashMap<String, UserSession> sessionUsernames = new ConcurrentHashMap<>();
+
+    // Secondary Index: Username -> SessionID (Lookup)
     private final ConcurrentHashMap<String, String> usernameSessions = new ConcurrentHashMap<>();
 
+    /**
+     * Initialize logical state for a new connection.
+     * @param sessionId The ID from the WebSocketSession
+     */
+    public void addSession(String sessionId) {
+        if (sessionId == null) {
+            logger.debug("UserRegistry addSession failed: sessionId is null.");
+            return;
+        }
+        sessionUsernames.put(sessionId, UserSession.create(sessionId));
+    }
+
+    /**
+     * Attempts to register a username.
+     */
     public boolean tryRegisterUser(String sessionId, String username) {
-        if (sessionId == null || username == null || username.isBlank()) return false;
+        if (sessionId == null || username == null || username.isBlank()) {
+            return false;
+        }
 
+        // Check if username taken
         String existingSession = usernameSessions.putIfAbsent(username, sessionId);
-        if (existingSession != null) return false;
+        if (existingSession != null) {
+            return false;
+        }
+        // Update UserSession State
+        UserSession updated = sessionUsernames.computeIfPresent(sessionId, (id, userSession) ->
+                userSession.withUsername(username)
+        );
 
-        String previousUsername = sessionUsernames.putIfAbsent(sessionId, username);
-        if (previousUsername != null) {
-            usernameSessions.remove(username, sessionId);
+        if (updated == null) {
+            usernameSessions.remove(username); // Rollback if session gone
             return false;
         }
 
@@ -31,24 +59,54 @@ public class UserRegistry {
         return true;
     }
 
-    public void removeUser(String sessionId) {
-        if (sessionId == null) return;
-        String username = sessionUsernames.remove(sessionId);
-        if (username != null) {
-            usernameSessions.remove(username);
+    /**
+     * Update the entire session state (e.g. changing Context).
+     */
+    public void updateUser(UserSession session) {
+        if (session != null) {
+            sessionUsernames.put(session.getSessionId(), session);
         }
     }
 
+    /**
+     * Remove user state on disconnect.
+     */
+    public void removeUser(String sessionId) {
+        if (sessionId == null) {
+            logger.debug("UserRegistry removeUser failed: sessionId is null.");
+            return;
+        }
+
+        UserSession removed = sessionUsernames.remove(sessionId);
+
+        if (removed != null && !MessageConstants.USER_ANONYMOUS.equals(removed.getUsername())) {
+            usernameSessions.remove(removed.getUsername());
+            logger.info("Removed user: '{}'", removed.getUsername());
+        }
+    }
+
+    // ========== LOOKUP METHODS ==========
+
+    public UserSession getSession(String sessionId) {
+        return sessionUsernames.get(sessionId);
+    }
+
     public String getUsername(String sessionId) {
-        return sessionUsernames.getOrDefault(sessionId, "Anonymous");
+        UserSession session = sessionUsernames.get(sessionId);
+        return (session != null) ? session.getUsername() : MessageConstants.USER_ANONYMOUS;
     }
 
     public boolean isUserRegistered(String sessionId) {
-        return sessionUsernames.containsKey(sessionId);
+        UserSession session = sessionUsernames.get(sessionId);
+        return session != null && !MessageConstants.USER_ANONYMOUS.equals(session.getUsername());
     }
 
     public boolean isUserOnline(String username) {
-        if (username == null) return false;
+        if (username == null) {
+            logger.debug("isUserOnline failed: username is null.");
+            return false;
+        }
+
         return usernameSessions.containsKey(username);
     }
 
@@ -65,6 +123,7 @@ public class UserRegistry {
     }
 
     public void logCountOnlineUsers() {
-        logger.info("All online connections: {}", sessionUsernames.size());
+        int count = Math.max(0, countOnlineUsers() - 1);
+        logger.info("All online connections: {}", count);
     }
 }

--- a/src/test/java/org/example/VChatTalk/command/CommandIntegrationTest.java
+++ b/src/test/java/org/example/VChatTalk/command/CommandIntegrationTest.java
@@ -171,4 +171,28 @@ class CommandIntegrationTest {
         CommandResult result = commandParser.parse(commandText);
         commandExecutor.execute(session, result);
     }
+
+    @Test
+    @DisplayName("Fail fast: Duplicate CommandType registration should throw exception")
+    void testDuplicateCommandTypeRegistration() {
+        // Arrange
+        IChatCommand login1 = new LoginCommand(userRegistry, responder);
+        IChatCommand login2 = new LoginCommand(userRegistry, responder); // SAME TYPE
+
+        List<IChatCommand> duplicatedCommands = List.of(
+                login1,
+                login2
+        );
+
+        // Act + Assert
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> new CommandExecutor(duplicatedCommands)
+        );
+
+        assertTrue(
+                ex.getMessage().toLowerCase().contains("duplicate"),
+                "Exception message should mention duplicate command type"
+        );
+    }
 }

--- a/src/test/java/org/example/VChatTalk/command/CommandIntegrationTest.java
+++ b/src/test/java/org/example/VChatTalk/command/CommandIntegrationTest.java
@@ -46,8 +46,9 @@ class CommandIntegrationTest {
 
         // 2. Wire up the Commands with the Real Registry
         List<IChatCommand> commands = Arrays.asList(
-                new LoginCommand(userRegistry, responder),   // Wait until sprint 6 to deploy.
-                new SelectCommand(userRegistry, responder, privateChatRegistry),
+                new LoginCommand(userRegistry, responder),
+                // Correct Constructor Order (Responder first, then Registry)
+                new SelectCommand(responder, userRegistry, privateChatRegistry),
                 new ListCommand(userRegistry, responder),
                 new HelpCommand(responder),
                 new LeaveCommand(userRegistry, responder, privateChatRegistry),
@@ -73,6 +74,10 @@ class CommandIntegrationTest {
         sessionRegistry.addSession(sessionAlice);
         sessionRegistry.addSession(sessionBob);
 
+        // Simulate ChatWebSocketHandler.afterConnectionEstablished
+        userRegistry.addSession("sess-alice");
+        userRegistry.addSession("sess-bob");
+
         // --- Phase 2: Login ---
         execute("/login Alice", sessionAlice);
 
@@ -92,8 +97,10 @@ class CommandIntegrationTest {
         // Verify Output (FR-12 Check)
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(responder, atLeastOnce()).sendSystem(eq(sessionAlice), captor.capture());
-        String successMsg = captor.getValue();
-        assertTrue(successMsg.contains("Bob")); // Message confirms target
+        // Verify that one of the messages contains "Bob" (success message)
+        boolean hasSuccessMsg = captor.getAllValues().stream()
+                .anyMatch(msg -> msg.contains("Bob"));
+        assertTrue(hasSuccessMsg, "Should receive success message containing target name");
 
         // --- Phase 4: Leave Chat ---
         execute("/leave", sessionAlice);
@@ -108,7 +115,10 @@ class CommandIntegrationTest {
     void testValidationLogic() throws IOException {
         WebSocketSession session = mock(WebSocketSession.class);
         when(session.getId()).thenReturn("sess-error-test");
+
         sessionRegistry.addSession(session);
+        // Initialize Session
+        userRegistry.addSession("sess-error-test");
 
         // 1. Select before login
         execute("/select Alice", session);
@@ -137,10 +147,12 @@ class CommandIntegrationTest {
         WebSocketSession s1 = mock(WebSocketSession.class);
         when(s1.getId()).thenReturn("s1");
         sessionRegistry.addSession(s1);
+        userRegistry.addSession("s1");
 
         WebSocketSession s2 = mock(WebSocketSession.class);
         when(s2.getId()).thenReturn("s2");
         sessionRegistry.addSession(s2);
+        userRegistry.addSession("s2");
 
         // s1 logs in first
         execute("/login Admin", s1);
@@ -158,23 +170,5 @@ class CommandIntegrationTest {
     private void execute(String commandText, WebSocketSession session) throws IOException {
         CommandResult result = commandParser.parse(commandText);
         commandExecutor.execute(session, result);
-    }
-
-    @Test
-    @DisplayName("Constructor should throw IllegalStateException when duplicate command types exist")
-    void testConstructor_DuplicateCommands() {
-        // Arrange: Create two dummy commands of the same type (e.g., both are SELECT).
-        IChatCommand cmd1 = mock(IChatCommand.class);
-        when(cmd1.getType()).thenReturn(CommandType.SELECT);
-
-        IChatCommand cmd2 = mock(IChatCommand.class);
-        when(cmd2.getType()).thenReturn(CommandType.SELECT); // Duplicate!
-
-        List<IChatCommand> commands = Arrays.asList(cmd1, cmd2);
-
-        // Act & Assert: Expect the constructor to throw an IllegalStateException.
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
-            new CommandExecutor(commands);
-        });
     }
 }

--- a/src/test/java/org/example/VChatTalk/command/impl/LeaveCommandTest.java
+++ b/src/test/java/org/example/VChatTalk/command/impl/LeaveCommandTest.java
@@ -12,14 +12,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,12 +29,26 @@ class LeaveCommandTest {
     @Mock private PrivateChatRegistry privateChatRegistry;
 
     private LeaveCommand leaveCommand;
-    private final String SESSION_ID = "s1";
+    private static final String SESSION_ID = "s1";
 
     @BeforeEach
     void setUp() {
         leaveCommand = new LeaveCommand(userRegistry, responder, privateChatRegistry);
         lenient().when(session.getId()).thenReturn(SESSION_ID);
+    }
+
+    @Test
+    @DisplayName("Fail: User not logged in -> ERR_NOT_LOGGED_IN")
+    void testExecute_NotLoggedIn() throws IOException {
+        // Arrange: user chưa login
+        when(userRegistry.getSession(SESSION_ID)).thenReturn(null);
+
+        // Act
+        leaveCommand.execute(session, new CommandResult(CommandType.LEAVE, null, null));
+
+        // Assert
+        verify(responder).sendError(session, MessageConstants.ERR_NOT_LOGGED_IN);
+        verifyNoInteractions(privateChatRegistry);
     }
 
     @Test
@@ -54,12 +66,12 @@ class LeaveCommandTest {
 
         verify(responder).sendError(session, MessageConstants.ERR_ALREADY_IN_GLOBAL);
         verify(privateChatRegistry, never()).removeTarget(anyString());
+        verify(userRegistry, never()).updateContext(any(), any());
     }
 
     @Test
     @DisplayName("Success: Leave private chat (Context is PRIVATE)")
-    void testExecute_Success() throws IOException {
-        // Arrange: User is in PRIVATE context
+    void testExecute_LeavePrivateChat() throws IOException {
         UserSession privateSession = UserSession.builder()
                 .sessionId(SESSION_ID)
                 .username("Alice")
@@ -68,17 +80,15 @@ class LeaveCommandTest {
 
         when(userRegistry.getSession(SESSION_ID)).thenReturn(privateSession);
 
-        // Act
         leaveCommand.execute(session, new CommandResult(CommandType.LEAVE, null, null));
 
-        // Assert 1: Registry Cleaned
+        // 1️⃣ Private registry cleaned
         verify(privateChatRegistry).removeTarget(SESSION_ID);
 
-        // Assert 2: Context Reset to GLOBAL
-        ArgumentCaptor<UserSession> captor = ArgumentCaptor.forClass(UserSession.class);
-        verify(userRegistry).updateUser(captor.capture());
-        assertEquals(ChatContext.GLOBAL, captor.getValue().getContext());
+        // 2️⃣ Context reset to GLOBAL (CHAT-3 compliant)
+        verify(userRegistry).updateContext(SESSION_ID, ChatContext.GLOBAL);
 
+        // 3️⃣ Feedback sent
         verify(responder).sendSystem(session, MessageConstants.MSG_PRIVATE_CHAT_LEAVE);
     }
 }

--- a/src/test/java/org/example/VChatTalk/command/impl/LeaveCommandTest.java
+++ b/src/test/java/org/example/VChatTalk/command/impl/LeaveCommandTest.java
@@ -3,6 +3,8 @@ package org.example.VChatTalk.command.impl;
 import org.example.VChatTalk.command.CommandResult;
 import org.example.VChatTalk.command.CommandType;
 import org.example.VChatTalk.command.MessageConstants;
+import org.example.VChatTalk.model.ChatContext;
+import org.example.VChatTalk.model.UserSession;
 import org.example.VChatTalk.util.PrivateChatRegistry;
 import org.example.VChatTalk.util.SystemResponseSender;
 import org.example.VChatTalk.util.UserRegistry;
@@ -10,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.socket.WebSocketSession;
@@ -28,51 +31,54 @@ class LeaveCommandTest {
     @Mock private PrivateChatRegistry privateChatRegistry;
 
     private LeaveCommand leaveCommand;
+    private final String SESSION_ID = "s1";
 
     @BeforeEach
     void setUp() {
         leaveCommand = new LeaveCommand(userRegistry, responder, privateChatRegistry);
+        lenient().when(session.getId()).thenReturn(SESSION_ID);
     }
 
     @Test
-    void testGetType() {
-        assertEquals(CommandType.LEAVE, leaveCommand.getType());
-    }
-
-    @Test
-    @DisplayName("Fail if user not logged in")
-    void testExecute_NotLoggedIn() throws IOException {
-        when(session.getId()).thenReturn("s1");
-        when(userRegistry.isUserRegistered("s1")).thenReturn(false);
-
-        leaveCommand.execute(session, new CommandResult(CommandType.LEAVE, null, null));
-
-        verify(responder).sendError(session, MessageConstants.ERR_NOT_LOGGED_IN);
-    }
-
-    @Test
-    @DisplayName("Fail if already in global chat (no target)")
+    @DisplayName("Fail if already in global chat (Context is GLOBAL)")
     void testExecute_AlreadyGlobal() throws IOException {
-        when(session.getId()).thenReturn("s1");
-        when(userRegistry.isUserRegistered("s1")).thenReturn(true);
-        when(privateChatRegistry.getTarget("s1")).thenReturn(null);
+        UserSession globalSession = UserSession.builder()
+                .sessionId(SESSION_ID)
+                .username("Alice")
+                .context(ChatContext.GLOBAL)
+                .build();
+
+        when(userRegistry.getSession(SESSION_ID)).thenReturn(globalSession);
 
         leaveCommand.execute(session, new CommandResult(CommandType.LEAVE, null, null));
 
-        verify(responder).sendSystem(session, MessageConstants.ERR_ALREADY_IN_GLOBAL);
+        verify(responder).sendError(session, MessageConstants.ERR_ALREADY_IN_GLOBAL);
         verify(privateChatRegistry, never()).removeTarget(anyString());
     }
 
     @Test
-    @DisplayName("Success: Leave private chat")
+    @DisplayName("Success: Leave private chat (Context is PRIVATE)")
     void testExecute_Success() throws IOException {
-        when(session.getId()).thenReturn("s1");
-        when(userRegistry.isUserRegistered("s1")).thenReturn(true);
-        when(privateChatRegistry.getTarget("s1")).thenReturn("Alice");
+        // Arrange: User is in PRIVATE context
+        UserSession privateSession = UserSession.builder()
+                .sessionId(SESSION_ID)
+                .username("Alice")
+                .context(ChatContext.PRIVATE)
+                .build();
 
+        when(userRegistry.getSession(SESSION_ID)).thenReturn(privateSession);
+
+        // Act
         leaveCommand.execute(session, new CommandResult(CommandType.LEAVE, null, null));
 
-        verify(privateChatRegistry).removeTarget("s1");
+        // Assert 1: Registry Cleaned
+        verify(privateChatRegistry).removeTarget(SESSION_ID);
+
+        // Assert 2: Context Reset to GLOBAL
+        ArgumentCaptor<UserSession> captor = ArgumentCaptor.forClass(UserSession.class);
+        verify(userRegistry).updateUser(captor.capture());
+        assertEquals(ChatContext.GLOBAL, captor.getValue().getContext());
+
         verify(responder).sendSystem(session, MessageConstants.MSG_PRIVATE_CHAT_LEAVE);
     }
 }

--- a/src/test/java/org/example/VChatTalk/command/impl/SelectCommandTest.java
+++ b/src/test/java/org/example/VChatTalk/command/impl/SelectCommandTest.java
@@ -3,6 +3,8 @@ package org.example.VChatTalk.command.impl;
 import org.example.VChatTalk.command.CommandResult;
 import org.example.VChatTalk.command.CommandType;
 import org.example.VChatTalk.command.MessageConstants;
+import org.example.VChatTalk.model.ChatContext;
+import org.example.VChatTalk.model.UserSession;
 import org.example.VChatTalk.util.PrivateChatRegistry;
 import org.example.VChatTalk.util.SystemResponseSender;
 import org.example.VChatTalk.util.UserRegistry;
@@ -10,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.socket.WebSocketSession;
@@ -23,24 +26,18 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class SelectCommandTest {
 
-    @Mock
-    private UserRegistry userRegistry;
-
-    @Mock
-    private PrivateChatRegistry privateChatRegistry;
-
-    @Mock
-    private SystemResponseSender responder;
-
-    @Mock
-    private WebSocketSession session;
+    @Mock private UserRegistry userRegistry;
+    @Mock private PrivateChatRegistry privateChatRegistry;
+    @Mock private SystemResponseSender responder;
+    @Mock private WebSocketSession session;
 
     private SelectCommand selectCommand;
+    private final String SESSION_ID = "sess-1";
 
     @BeforeEach
     void setUp() {
-        // Inject Mocks vào Command
-        selectCommand = new SelectCommand(userRegistry, responder, privateChatRegistry);
+        selectCommand = new SelectCommand(responder, userRegistry, privateChatRegistry);
+        lenient().when(session.getId()).thenReturn(SESSION_ID);
     }
 
     @Test
@@ -52,90 +49,42 @@ class SelectCommandTest {
     @Test
     @DisplayName("Fail if user is not logged in")
     void testExecute_NotLoggedIn() throws IOException {
-        // Simulator is not logged in yet
-        when(session.getId()).thenReturn("sess-1");
-        when(userRegistry.isUserRegistered("sess-1")).thenReturn(false);
+        // Mock session trả về null hoặc Anonymous
+        when(userRegistry.getSession(SESSION_ID)).thenReturn(null);
 
         CommandResult result = new CommandResult(CommandType.SELECT, "Alice", null);
         selectCommand.execute(session, result);
 
-        // Verify: The error ERR_NOT_LOGGED_IN must be submitted.
         verify(responder).sendError(session, MessageConstants.ERR_NOT_LOGGED_IN);
-        // Verify: Do not set targets
         verify(privateChatRegistry, never()).setTarget(anyString(), anyString());
     }
 
     @Test
-    @DisplayName("Fail if argument (target user) is missing")
-    void testExecute_MissingArgument() throws IOException {
-        when(session.getId()).thenReturn("sess-1");
-        when(userRegistry.isUserRegistered("sess-1")).thenReturn(true);
-
-        // Argument is null
-        CommandResult result = new CommandResult(CommandType.SELECT, null, null);
-        selectCommand.execute(session, result);
-
-        verify(responder).sendError(session, String.format(MessageConstants.ERR_MISSING_ARG_USER, "/select"));
-    }
-
-    @Test
-    @DisplayName("Fail if username contains spaces")
-    void testExecute_SpaceInUsername() throws IOException {
-        when(session.getId()).thenReturn("sess-1");
-        when(userRegistry.isUserRegistered("sess-1")).thenReturn(true);
-
-        CommandResult result = new CommandResult(CommandType.SELECT, "User Name", null);
-        selectCommand.execute(session, result);
-
-        verify(responder).sendError(session, MessageConstants.ERR_USERNAME_CONTAIN_SPACE);
-    }
-
-    @Test
-    @DisplayName("Fail if self-chat")
-    void testExecute_SelfChat() throws IOException {
-        when(session.getId()).thenReturn("sess-1");
-        when(userRegistry.isUserRegistered("sess-1")).thenReturn(true);
-        when(userRegistry.getUsername("sess-1")).thenReturn("Alice");
-
-        // Target is Alice (yourself)
-        CommandResult result = new CommandResult(CommandType.SELECT, "Alice", null);
-        selectCommand.execute(session, result);
-
-        verify(responder).sendError(session, MessageConstants.ERR_SELF_CHAT);
-    }
-
-    @Test
-    @DisplayName("Fail if target user is offline")
-    void testExecute_TargetOffline() throws IOException {
-        when(session.getId()).thenReturn("sess-1");
-        when(userRegistry.isUserRegistered("sess-1")).thenReturn(true);
-        when(userRegistry.getUsername("sess-1")).thenReturn("Alice");
-
-        // Bob offline
-        when(userRegistry.isUserOnline("Bob")).thenReturn(false);
-
-        CommandResult result = new CommandResult(CommandType.SELECT, "Bob", null);
-        selectCommand.execute(session, result);
-
-        verify(responder).sendError(session, String.format(MessageConstants.ERR_USER_OFFLINE, "Bob"));
-    }
-
-    @Test
-    @DisplayName("Success: Switch to private chat")
+    @DisplayName("Success: Switch to private chat and Update Context")
     void testExecute_Success() throws IOException {
-        when(session.getId()).thenReturn("sess-1");
-        when(userRegistry.isUserRegistered("sess-1")).thenReturn(true);
-        when(userRegistry.getUsername("sess-1")).thenReturn("Alice");
+        // Arrange
+        UserSession initialSession = UserSession.builder()
+                .sessionId(SESSION_ID)
+                .username("Alice")
+                .context(ChatContext.GLOBAL)
+                .build();
 
-        // Bob online
+        when(userRegistry.getSession(SESSION_ID)).thenReturn(initialSession);
         when(userRegistry.isUserOnline("Bob")).thenReturn(true);
 
+        // Act
         CommandResult result = new CommandResult(CommandType.SELECT, "Bob", null);
         selectCommand.execute(session, result);
 
-        // Important verification: You must call setTarget.
-        verify(privateChatRegistry).setTarget("sess-1", "Bob");
-        // Verify: Notification sent successfully
+        // Assert 1: Registry updated
+        verify(privateChatRegistry).setTarget(SESSION_ID, "Bob");
+
+        // Assert 2: User Context updated to PRIVATE
+        ArgumentCaptor<UserSession> captor = ArgumentCaptor.forClass(UserSession.class);
+        verify(userRegistry).updateUser(captor.capture());
+        assertEquals(ChatContext.PRIVATE, captor.getValue().getContext());
+
+        // Assert 3: Notification
         verify(responder).sendSystem(session, String.format(MessageConstants.MSG_PRIVATE_CHAT_START, "Bob"));
     }
 }

--- a/src/test/java/org/example/VChatTalk/command/impl/SelectCommandTest.java
+++ b/src/test/java/org/example/VChatTalk/command/impl/SelectCommandTest.java
@@ -12,27 +12,25 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class SelectCommandTest {
 
+    @Mock private SystemResponseSender responder;
     @Mock private UserRegistry userRegistry;
     @Mock private PrivateChatRegistry privateChatRegistry;
-    @Mock private SystemResponseSender responder;
     @Mock private WebSocketSession session;
 
     private SelectCommand selectCommand;
-    private final String SESSION_ID = "sess-1";
+
+    private static final String SESSION_ID = "s1";
 
     @BeforeEach
     void setUp() {
@@ -41,50 +39,94 @@ class SelectCommandTest {
     }
 
     @Test
-    @DisplayName("Should return SELECT type")
-    void testGetType() {
-        assertEquals(CommandType.SELECT, selectCommand.getType());
-    }
-
-    @Test
-    @DisplayName("Fail if user is not logged in")
-    void testExecute_NotLoggedIn() throws IOException {
-        // Mock session trả về null hoặc Anonymous
+    @DisplayName("Fail: User not logged in")
+    void testSelect_NotLoggedIn() throws IOException {
         when(userRegistry.getSession(SESSION_ID)).thenReturn(null);
 
-        CommandResult result = new CommandResult(CommandType.SELECT, "Alice", null);
-        selectCommand.execute(session, result);
+        selectCommand.execute(session,
+                new CommandResult(CommandType.SELECT, "Bob", null));
 
         verify(responder).sendError(session, MessageConstants.ERR_NOT_LOGGED_IN);
-        verify(privateChatRegistry, never()).setTarget(anyString(), anyString());
+        verifyNoInteractions(privateChatRegistry);
     }
 
     @Test
-    @DisplayName("Success: Switch to private chat and Update Context")
-    void testExecute_Success() throws IOException {
-        // Arrange
-        UserSession initialSession = UserSession.builder()
+    @DisplayName("Fail: Missing username argument")
+    void testSelect_MissingArgument() throws IOException {
+        mockLoggedInUser("Alice");
+
+        selectCommand.execute(session,
+                new CommandResult(CommandType.SELECT, null, null));
+
+        verify(responder).sendError(
+                session,
+                String.format(MessageConstants.ERR_MISSING_ARG_USER, "/select")
+        );
+    }
+
+    @Test
+    @DisplayName("Fail: Username contains spaces")
+    void testSelect_UsernameWithSpaces() throws IOException {
+        mockLoggedInUser("Alice");
+
+        selectCommand.execute(session,
+                new CommandResult(CommandType.SELECT, "Bob Smith", null));
+
+        verify(responder).sendError(session, MessageConstants.ERR_USERNAME_CONTAIN_SPACE);
+    }
+
+    @Test
+    @DisplayName("Fail: Self chat prevention")
+    void testSelect_SelfChat() throws IOException {
+        mockLoggedInUser("Alice");
+
+        selectCommand.execute(session,
+                new CommandResult(CommandType.SELECT, "Alice", null));
+
+        verify(responder).sendError(session, MessageConstants.ERR_SELF_CHAT);
+    }
+
+    @Test
+    @DisplayName("Fail: Target user offline")
+    void testSelect_UserOffline() throws IOException {
+        mockLoggedInUser("Alice");
+        when(userRegistry.isUserOnline("Bob")).thenReturn(false);
+
+        selectCommand.execute(session,
+                new CommandResult(CommandType.SELECT, "Bob", null));
+
+        verify(responder).sendError(
+                session,
+                String.format(MessageConstants.ERR_USER_OFFLINE, "Bob")
+        );
+    }
+
+    @Test
+    @DisplayName("Success: Switch to PRIVATE chat")
+    void testSelect_Success() throws IOException {
+        mockLoggedInUser("Alice");
+        when(userRegistry.isUserOnline("Bob")).thenReturn(true);
+
+        selectCommand.execute(session,
+                new CommandResult(CommandType.SELECT, "Bob", null));
+
+        verify(privateChatRegistry).setTarget(SESSION_ID, "Bob");
+        verify(userRegistry).updateContext(SESSION_ID, ChatContext.PRIVATE);
+
+        verify(responder).sendSystem(
+                session,
+                String.format(MessageConstants.MSG_PRIVATE_CHAT_START, "Bob")
+        );
+    }
+
+    // ===== Helper =====
+    private void mockLoggedInUser(String username) {
+        UserSession sessionState = UserSession.builder()
                 .sessionId(SESSION_ID)
-                .username("Alice")
+                .username(username)
                 .context(ChatContext.GLOBAL)
                 .build();
 
-        when(userRegistry.getSession(SESSION_ID)).thenReturn(initialSession);
-        when(userRegistry.isUserOnline("Bob")).thenReturn(true);
-
-        // Act
-        CommandResult result = new CommandResult(CommandType.SELECT, "Bob", null);
-        selectCommand.execute(session, result);
-
-        // Assert 1: Registry updated
-        verify(privateChatRegistry).setTarget(SESSION_ID, "Bob");
-
-        // Assert 2: User Context updated to PRIVATE
-        ArgumentCaptor<UserSession> captor = ArgumentCaptor.forClass(UserSession.class);
-        verify(userRegistry).updateUser(captor.capture());
-        assertEquals(ChatContext.PRIVATE, captor.getValue().getContext());
-
-        // Assert 3: Notification
-        verify(responder).sendSystem(session, String.format(MessageConstants.MSG_PRIVATE_CHAT_START, "Bob"));
+        when(userRegistry.getSession(SESSION_ID)).thenReturn(sessionState);
     }
 }

--- a/src/test/java/org/example/VChatTalk/handler/ChatWebSocketHandlerTest.java
+++ b/src/test/java/org/example/VChatTalk/handler/ChatWebSocketHandlerTest.java
@@ -17,8 +17,6 @@ import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
-import java.util.List;
-
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -56,33 +54,24 @@ class ChatWebSocketHandlerTest {
     }
 
     @Test
-    @DisplayName("On Disconnect: Should cleanup and notify followers")
+    @DisplayName("On Disconnect: Should cleanup Registries explicitly")
     void afterConnectionClosed_Success() {
         String username = "Alice";
-        String followerId = "follower-session";
-        WebSocketSession followerSession = mock(WebSocketSession.class);
 
-        // Setup user info
+        // Mock behaviors
         when(userRegistry.getUsername(SESSION_ID)).thenReturn(username);
         when(chatService.handleLeave(SESSION_ID)).thenReturn(MessageDTO.builder().content("Bye").build());
 
-        // Setup a follower (someone private chatting with Alice)
-        when(privateChatRegistry.getSessionsTargeting(username)).thenReturn(List.of(followerId));
-        when(sessionRegistry.findSessionById(followerId)).thenReturn(followerSession);
-        when(followerSession.isOpen()).thenReturn(true);
-
+        // Execute
         chatWebSocketHandler.afterConnectionClosed(session, CloseStatus.NORMAL);
 
-        // Verify Cleanup
+        // Verify CLEANUP Logic (Moved from Service to Handler)
         verify(rateLimiter).removeSession(SESSION_ID);
         verify(sessionRegistry).removeSession(SESSION_ID);
-        verify(broadcastService).broadcast(any(MessageDTO.class), eq(null));
+        verify(userRegistry).removeUser(SESSION_ID); // QUAN TRỌNG: Verify handler gọi hàm xóa user
 
-        // Verify Follower Notification
-        verify(privateChatRegistry).removeTarget(followerId);
-        try {
-            verify(systemResponseSender).sendSystem(eq(followerSession), anyString());
-        } catch (Exception e) { /* ignored for test */ }
+        // Verify Broadcast
+        verify(broadcastService).broadcast(any(MessageDTO.class), eq(null));
     }
 
     // ========== MESSAGE TESTS ==========

--- a/src/test/java/org/example/VChatTalk/handler/ChatWebSocketHandlerTest.java
+++ b/src/test/java/org/example/VChatTalk/handler/ChatWebSocketHandlerTest.java
@@ -17,6 +17,8 @@ import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
+import java.util.Set;
+
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -99,5 +101,52 @@ class ChatWebSocketHandlerTest {
 
         verify(systemResponseSender).sendError(session, MessageConstants.ERR_RATE_LIMIT);
         verifyNoInteractions(messageProcessor);
+    }
+
+    @Test
+    @DisplayName("On Disconnect: Notify followers and cleanup private chat targets")
+    void afterConnectionClosed_ShouldNotifyFollowersAndCleanupTargets() throws Exception {
+        // Alice disconnects
+        String aliceSessionId = SESSION_ID;
+        String aliceUsername = "Alice";
+
+        // Two followers chatting with Alice
+        String bobSessionId = "sess-bob";
+        String charlieSessionId = "sess-charlie";
+
+        WebSocketSession bobSession = mock(WebSocketSession.class);
+        WebSocketSession charlieSession = mock(WebSocketSession.class);
+
+        when(bobSession.isOpen()).thenReturn(true);
+        when(charlieSession.isOpen()).thenReturn(true);
+
+        // Mock registries
+        when(userRegistry.getUsername(aliceSessionId)).thenReturn(aliceUsername);
+        when(privateChatRegistry.getSessionsTargeting(aliceUsername))
+                .thenReturn(Set.of(bobSessionId, charlieSessionId));
+
+        when(sessionRegistry.findSessionById(bobSessionId)).thenReturn(bobSession);
+        when(sessionRegistry.findSessionById(charlieSessionId)).thenReturn(charlieSession);
+
+        // Execute
+        chatWebSocketHandler.afterConnectionClosed(session, CloseStatus.NORMAL);
+
+        // 1️⃣ Followers should be cleaned up
+        verify(privateChatRegistry).removeTarget(bobSessionId);
+        verify(privateChatRegistry).removeTarget(charlieSessionId);
+
+        // 2️⃣ Followers should be notified
+        verify(systemResponseSender).sendSystem(
+                eq(bobSession),
+                contains("Alice")
+        );
+        verify(systemResponseSender).sendSystem(
+                eq(charlieSession),
+                contains("Alice")
+        );
+
+        // 3️⃣ Alice should be removed
+        verify(userRegistry).removeUser(aliceSessionId);
+        verify(sessionRegistry).removeSession(aliceSessionId);
     }
 }

--- a/src/test/java/org/example/VChatTalk/service/ChatServiceTest.java
+++ b/src/test/java/org/example/VChatTalk/service/ChatServiceTest.java
@@ -1,7 +1,9 @@
 package org.example.VChatTalk.service;
 
+import org.example.VChatTalk.model.ChatContext;
 import org.example.VChatTalk.model.MessageDTO;
 import org.example.VChatTalk.model.MessageType;
+import org.example.VChatTalk.model.UserSession;
 import org.example.VChatTalk.util.PrivateChatRegistry;
 import org.example.VChatTalk.util.SessionRegistry;
 import org.example.VChatTalk.util.UserRegistry;
@@ -68,16 +70,23 @@ class ChatServiceTest {
         assertThrows(IllegalArgumentException.class, () -> chatService.handleJoin(SENDER_ID, joinDto));
     }
 
-    // ========== ROUTING TESTS ==========
+    // ========== ROUTING TESTS (UPDATED FOR CONTEXT) ==========
 
     @Test
-    @DisplayName("Route - Should broadcast to global when no private target is set")
+    @DisplayName("Route - Should broadcast to global when Context is GLOBAL")
     void routeMessage_GlobalMode() throws IOException {
         MessageDTO dto = MessageDTO.builder().content("Hello World").build();
 
+        UserSession globalSession = UserSession.builder()
+                .sessionId(SENDER_ID)
+                .username(SENDER_NAME)
+                .context(ChatContext.GLOBAL)
+                .build();
+
+        when(userRegistry.getSession(SENDER_ID)).thenReturn(globalSession);
+
         when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
         when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
-        when(privateChatRegistry.getTarget(SENDER_ID)).thenReturn(null);
 
         chatService.routeMessage(senderSession, dto);
 
@@ -86,39 +95,43 @@ class ChatServiceTest {
     }
 
     @Test
-    @DisplayName("Route - Should send private message when target is set")
+    @DisplayName("Route - Should send private message when Context is PRIVATE")
     void routeMessage_PrivateMode() throws IOException {
         String targetName = "Bob";
         String targetSessId = "session-456";
         WebSocketSession targetSession = mock(WebSocketSession.class);
-
         MessageDTO dto = MessageDTO.builder().content("Secret").build();
 
-        // Setup registries
+        UserSession privateSession = UserSession.builder()
+                .sessionId(SENDER_ID)
+                .username(SENDER_NAME)
+                .context(ChatContext.PRIVATE)
+                .build();
+
+        when(userRegistry.getSession(SENDER_ID)).thenReturn(privateSession);
+
         when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
         when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
+
         when(privateChatRegistry.getTarget(SENDER_ID)).thenReturn(targetName);
 
-        // Setup Bob's availability
         when(userRegistry.getSessionId(targetName)).thenReturn(targetSessId);
         when(sessionRegistry.findSessionById(targetSessId)).thenReturn(targetSession);
         when(targetSession.isOpen()).thenReturn(true);
 
         chatService.routeMessage(senderSession, dto);
 
-        // Verify Bob gets the message and Alice gets an echo
         verify(broadcastService, times(2)).sendToSession(any(), any());
 
-        // Verify formatting for Target
         ArgumentCaptor<MessageDTO> msgCaptor = ArgumentCaptor.forClass(MessageDTO.class);
         verify(broadcastService).sendToSession(eq(targetSession), msgCaptor.capture());
         assertTrue(msgCaptor.getValue().getContent().contains("[PM]"));
     }
 
-    // ========== LEAVE TESTS ==========
+    // ========== LEAVE TESTS (UPDATED CLEANUP LOGIC) ==========
 
     @Test
-    @DisplayName("Leave - Should remove user and return system message")
+    @DisplayName("Leave - Should return message BUT NOT clean registry (Handler job now)")
     void handleLeave_Success() {
         when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
         when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
@@ -126,8 +139,9 @@ class ChatServiceTest {
         MessageDTO result = chatService.handleLeave(SENDER_ID);
 
         assertNotNull(result);
-        verify(userRegistry).removeUser(SENDER_ID);
-        verify(privateChatRegistry).removeTarget(SENDER_ID);
+
+        verify(userRegistry, never()).removeUser(SENDER_ID);
+        verify(privateChatRegistry, never()).removeTarget(SENDER_ID);
     }
 
     @Test

--- a/src/test/java/org/example/VChatTalk/util/PrivateChatRegistryTest.java
+++ b/src/test/java/org/example/VChatTalk/util/PrivateChatRegistryTest.java
@@ -47,7 +47,7 @@ class PrivateChatRegistryTest {
         assertNull(registry.getTarget(null));
     }
 
-    // ========== REVERSE LOOKUP ==========
+    // ========== REVERSE LOOKUP (O(1) Feature) ==========
 
     @Test
     @DisplayName("getSessionsTargeting: Multiple sessions → 1 user")
@@ -56,73 +56,51 @@ class PrivateChatRegistryTest {
         registry.setTarget("s2", "alice");
         registry.setTarget("s3", "bob");
 
-        List<String> aliceFollowers = registry.getSessionsTargeting("alice");
+        List<String> aliceFollowers = List.copyOf(registry.getSessionsTargeting("alice"));
         assertEquals(2, aliceFollowers.size());
         assertTrue(aliceFollowers.contains("s1"));
         assertTrue(aliceFollowers.contains("s2"));
     }
 
     @Test
-    @DisplayName("getSessionsTargeting: No followers → empty list")
-    void testGetSessionsTargeting_Empty() {
-        List<String> result = registry.getSessionsTargeting("nobody");
-        assertNotNull(result);
-        assertTrue(result.isEmpty());
+    @DisplayName("Memory Leak Check: Should cleanup Reverse Index when empty")
+    void testReverseIndexCleanup() {
+        // 1. Register s1 targeting alice
+        registry.setTarget("s1", "alice");
+        assertFalse(registry.getSessionsTargeting("alice").isEmpty());
+
+        // 2. Remove s1
+        registry.removeTarget("s1");
+
+        // 3. Verify alice is completely gone from the reverse index
+        assertTrue(registry.getSessionsTargeting("alice").isEmpty(),
+                "Reverse index should be empty/cleaned up");
     }
 
     @Test
     @DisplayName("getSessionsTargeting: Unmodifiable list")
     void testGetSessionsTargeting_Unmodifiable() {
         registry.setTarget("s1", "alice");
-        List<String> result = registry.getSessionsTargeting("alice");
+        var result = registry.getSessionsTargeting("alice");
 
         assertThrows(UnsupportedOperationException.class, () -> result.add("s2"));
-    }
-
-    // ========== CONCURRENCY ==========
-
-    @Test
-    @DisplayName("Concurrent setTarget: No race conditions")
-    void testConcurrentSetTarget() throws InterruptedException {
-        Runnable setAlice = () -> registry.setTarget("sess-race", "alice");
-
-        Thread t1 = new Thread(setAlice);
-        Thread t2 = new Thread(setAlice);
-        t1.start(); t2.start();
-        t1.join(); t2.join();
-
-        assertEquals("alice", registry.getTarget("sess-race"));
     }
 
     // ========== EDGE CASES ==========
 
     @Test
-    @DisplayName("Remove non-existent target")
-    void testRemoveNonExistent() {
-        assertDoesNotThrow(() -> registry.removeTarget("non-existent"));
-        assertNull(registry.getTarget("non-existent"));
-    }
-
-    @Test
-    @DisplayName("Multiple targets for same session → last wins")
-    void testMultipleSetTarget() {
+    @DisplayName("Switch Target: Should clean old mapping and add new")
+    void testSwitchTarget() {
+        // s1: alice -> bob
         registry.setTarget("s1", "alice");
+        assertTrue(registry.getSessionsTargeting("alice").contains("s1"));
+
         registry.setTarget("s1", "bob");
+
+        // Verify s1 removed from alice
+        assertFalse(registry.getSessionsTargeting("alice").contains("s1"));
+        // Verify s1 added to bob
+        assertTrue(registry.getSessionsTargeting("bob").contains("s1"));
         assertEquals("bob", registry.getTarget("s1"));
-
-        List<String> aliceFollowers = registry.getSessionsTargeting("alice");
-        assertTrue(aliceFollowers.isEmpty());
-    }
-
-    @Test
-    @DisplayName("Clear all targets for user")
-    void testRemoveAllFollowers() {
-        registry.setTarget("s1", "alice");
-        registry.setTarget("s2", "alice");
-
-        registry.removeTarget("s1");
-        List<String> followers = registry.getSessionsTargeting("alice");
-        assertEquals(1, followers.size());  // s2 still targeting
-        assertTrue(followers.contains("s2"));
     }
 }

--- a/src/test/java/org/example/VChatTalk/util/PrivateChatRegistryTest.java
+++ b/src/test/java/org/example/VChatTalk/util/PrivateChatRegistryTest.java
@@ -7,6 +7,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -78,7 +81,7 @@ class PrivateChatRegistryTest {
     }
 
     @Test
-    @DisplayName("getSessionsTargeting: Unmodifiable list")
+    @DisplayName("getSessionsTargeting: Unmodifiable set")
     void testGetSessionsTargeting_Unmodifiable() {
         registry.setTarget("s1", "alice");
         var result = registry.getSessionsTargeting("alice");
@@ -102,5 +105,79 @@ class PrivateChatRegistryTest {
         // Verify s1 added to bob
         assertTrue(registry.getSessionsTargeting("bob").contains("s1"));
         assertEquals("bob", registry.getTarget("s1"));
+    }
+
+    @Test
+    @DisplayName("Concurrency: setTarget & removeTarget concurrently should be thread-safe")
+    void testConcurrentAccess() throws InterruptedException {
+        int threadCount = 20;
+        int iterations = 1_000;
+        String target = "alice";
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final String sessionId = "s" + i;
+            executor.submit(() -> {
+                try {
+                    for (int j = 0; j < iterations; j++) {
+                        registry.setTarget(sessionId, target);
+                        registry.removeTarget(sessionId);
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+
+        // Sau tất cả: reverse index phải sạch
+        assertTrue(
+                registry.getSessionsTargeting(target).isEmpty(),
+                "Reverse index should be empty after concurrent modifications"
+        );
+    }
+
+    @Test
+    @DisplayName("Remove non-existent target should be safe")
+    void testRemoveNonExistentTarget() {
+        assertDoesNotThrow(() -> registry.removeTarget("unknown-session"));
+    }
+
+    @Test
+    @DisplayName("Reverse index cleanup when last follower is removed")
+    void testReverseIndexCleanup_MultipleFollowers() {
+        registry.setTarget("s1", "alice");
+        registry.setTarget("s2", "alice");
+
+        assertEquals(2, registry.getSessionsTargeting("alice").size());
+
+        registry.removeTarget("s1");
+        assertEquals(1, registry.getSessionsTargeting("alice").size());
+
+        registry.removeTarget("s2");
+
+        // Sau khi follower cuối cùng rời đi
+        assertTrue(
+                registry.getSessionsTargeting("alice").isEmpty(),
+                "Reverse index must be removed when last follower leaves"
+        );
+    }
+
+    @Test
+    @DisplayName("Multiple target switches should keep reverse index consistent")
+    void testMultipleTargetSwitches() {
+        registry.setTarget("s1", "alice");
+        registry.setTarget("s1", "bob");
+        registry.setTarget("s1", "charlie");
+
+        assertFalse(registry.getSessionsTargeting("alice").contains("s1"));
+        assertFalse(registry.getSessionsTargeting("bob").contains("s1"));
+        assertTrue(registry.getSessionsTargeting("charlie").contains("s1"));
+
+        assertEquals("charlie", registry.getTarget("s1"));
     }
 }

--- a/src/test/java/org/example/VChatTalk/util/UserRegistryTest.java
+++ b/src/test/java/org/example/VChatTalk/util/UserRegistryTest.java
@@ -26,6 +26,8 @@ class UserRegistryTest {
     @Test
     @DisplayName("Success: Register new user")
     void testTryRegisterUser_Success() {
+        registry.addSession("sess-1");
+
         boolean result = registry.tryRegisterUser("sess-1", "alice");
         assertTrue(result);
         assertEquals("alice", registry.getUsername("sess-1"));
@@ -36,6 +38,9 @@ class UserRegistryTest {
     @Test
     @DisplayName("Fail: Username already taken")
     void testTryRegisterUser_UsernameTaken() {
+        registry.addSession("sess-1");
+        registry.addSession("sess-2");
+
         // First registration succeeds
         registry.tryRegisterUser("sess-1", "alice");
 
@@ -48,8 +53,20 @@ class UserRegistryTest {
     @Test
     @DisplayName("Fail: Session already registered")
     void testTryRegisterUser_SessionTaken() {
+        registry.addSession("sess-1");
+
         registry.tryRegisterUser("sess-1", "alice");
-        boolean result = registry.tryRegisterUser("sess-1", "bob");  // Same session
+        boolean result = registry.tryRegisterUser("sess-1", "bob");  // Same session trying to change name
+
+        // Note: Depending on logic, this might be false (cannot re-register) or true (rename).
+        // Based on your UserRegistry logic: putIfAbsent(username) check happens first.
+        // "bob" is free, but let's check strict logic.
+        // Assuming implementation blocks re-registration if not handled explicitly.
+
+        // Correct behavior check:
+        // If tryRegisterUser allows rename, this might pass.
+        // If it strictly checks state, it might fail.
+        // Let's assume standard flow: One user per session.
         assertFalse(result);
         assertEquals("alice", registry.getUsername("sess-1"));  // alice kept
     }
@@ -57,6 +74,8 @@ class UserRegistryTest {
     @Test
     @DisplayName("Fail: Null/blank inputs")
     void testTryRegisterUser_InvalidInputs() {
+        registry.addSession("sess-1");
+
         assertFalse(registry.tryRegisterUser(null, "alice"));
         assertFalse(registry.tryRegisterUser("sess-1", null));
         assertFalse(registry.tryRegisterUser("sess-1", ""));
@@ -68,6 +87,8 @@ class UserRegistryTest {
     @Test
     @DisplayName("getUsername: Returns Anonymous for unregistered")
     void testGetUsername_Unregistered() {
+        // Even if session exists but not registered
+        registry.addSession("sess-999");
         assertEquals("Anonymous", registry.getUsername("sess-999"));
     }
 
@@ -89,17 +110,21 @@ class UserRegistryTest {
     @Test
     @DisplayName("isUserRegistered: False for unregistered session")
     void testIsUserRegistered_False() {
+        registry.addSession("sess-unknown");
         assertFalse(registry.isUserRegistered("sess-unknown"));
     }
-
     // ========== REMOVAL ==========
 
     @Test
     @DisplayName("removeUser: Cleanup both mappings")
     void testRemoveUser() {
+        registry.addSession("sess-1");
         registry.tryRegisterUser("sess-1", "alice");
+
         registry.removeUser("sess-1");
 
+        // After remove, getUsername should return null (session gone) or Anonymous if we handle null gracefully
+        // In your UserRegistry: getUsername calls sessionUsernames.get(). If null -> returns "Anonymous".
         assertEquals("Anonymous", registry.getUsername("sess-1"));
         assertFalse(registry.isUserOnline("alice"));
         assertNull(registry.getSessionId("alice"));
@@ -110,12 +135,15 @@ class UserRegistryTest {
     void testRemoveUser_Unregistered() {
         assertDoesNotThrow(() -> registry.removeUser("sess-unknown"));
     }
-
     // ========== LISTING & COUNTING ==========
 
     @Test
     @DisplayName("countOnlineUsers: Accurate count")
     void testCountOnlineUsers() {
+        registry.addSession("s1");
+        registry.addSession("s2");
+        registry.addSession("s3");
+
         registry.tryRegisterUser("s1", "a");
         registry.tryRegisterUser("s2", "b");
         registry.tryRegisterUser("s3", "c");
@@ -125,6 +153,9 @@ class UserRegistryTest {
     @Test
     @DisplayName("getAllOnlineUsers: Returns all registered users")
     void testGetAllOnlineUsers() {
+        registry.addSession("s1");
+        registry.addSession("s2");
+
         registry.tryRegisterUser("s1", "alice");
         registry.tryRegisterUser("s2", "bob");
 
@@ -138,6 +169,7 @@ class UserRegistryTest {
     @Test
     @DisplayName("getAllOnlineUsers: Unmodifiable + thread-safe")
     void testGetAllOnlineUsers_Unmodifiable() {
+        registry.addSession("s1");
         registry.tryRegisterUser("s1", "alice");
         Collection<String> users = registry.getAllOnlineUsers();
 
@@ -149,6 +181,8 @@ class UserRegistryTest {
     @Test
     @DisplayName("Concurrent registration: Atomic username reservation")
     void testConcurrentRegistration() throws InterruptedException {
+        registry.addSession("sess-race");
+
         // Simulate race condition
         Runnable registerAlice = () -> registry.tryRegisterUser("sess-race", "alice");
 
@@ -166,6 +200,7 @@ class UserRegistryTest {
     @Test
     @DisplayName("Long usernames handled correctly")
     void testLongUsername() {
+        registry.addSession("s1");
         String longName = "a".repeat(50);
         boolean result = registry.tryRegisterUser("s1", longName);
         assertTrue(result);  // No length limit in registry
@@ -175,6 +210,7 @@ class UserRegistryTest {
     @Test
     @DisplayName("Special characters in username")
     void testSpecialCharacters() {
+        registry.addSession("s1");
         registry.tryRegisterUser("s1", "user@123!");
         assertEquals("user@123!", registry.getUsername("s1"));
         assertTrue(registry.isUserOnline("user@123!"));

--- a/src/test/java/org/example/VChatTalk/util/UserRegistryTest.java
+++ b/src/test/java/org/example/VChatTalk/util/UserRegistryTest.java
@@ -58,15 +58,7 @@ class UserRegistryTest {
         registry.tryRegisterUser("sess-1", "alice");
         boolean result = registry.tryRegisterUser("sess-1", "bob");  // Same session trying to change name
 
-        // Note: Depending on logic, this might be false (cannot re-register) or true (rename).
-        // Based on your UserRegistry logic: putIfAbsent(username) check happens first.
-        // "bob" is free, but let's check strict logic.
-        // Assuming implementation blocks re-registration if not handled explicitly.
-
-        // Correct behavior check:
-        // If tryRegisterUser allows rename, this might pass.
-        // If it strictly checks state, it might fail.
-        // Let's assume standard flow: One user per session.
+        // Session cannot re-register with a different username while still logged in
         assertFalse(result);
         assertEquals("alice", registry.getUsername("sess-1"));  // alice kept
     }


### PR DESCRIPTION
### 🚀 Summary

This PR implements the core refactoring of the Chat System, transitioning from simple state management to a robust **Stateful Context Architecture** (`GLOBAL`, `PRIVATE`, `ROOM`). It also standardizes the connection **Lifecycle Management** to prevent memory leaks and ensure data consistency across registries.

<img width="1292" height="672" alt="BuildSuccess" src="https://github.com/user-attachments/assets/832b29c0-dbd9-47c3-81ce-500f771fea44" />

### 🛠️ Key Changes

#### 1. Architecture & Model

* **`UserSession`**: Refactored to be an **Immutable Object**. Added `ChatContext` field to track user state (currently `GLOBAL`, `PRIVATE`, `ROOM`).
* **`ChatContext`**: New Enum defining the three operational modes.

#### 2. Registry Layer (Data Store)

* **`UserRegistry`**:
* Decoupled "Physical" (Session ID) from "Logical" (Username) tracking.
* **Bugfix:** Fixed logic allowing active sessions to overwrite/rename usernames. Sessions must now logout before re-registering.
* Added `updateUser()` method to support immutable state updates (Context transitions).

* **`PrivateChatRegistry`**:
* Implemented **Reverse Index** (`target -> senders`) for **O(1)** lookup performance.
* Added automatic cleanup logic when users disconnect.

#### 3. Service Layer & Logic

* **`ChatService`**:
* Refactored `routeMessage` to use `switch(context)` for cleaner routing logic instead of nested if-else.
* **SRP Fix:** Removed side-effect cleanup logic (deleting users) from the Service. The Service is now **Pure Logic**.

* **`ChatWebSocketHandler`**:
* Now fully responsible for **Lifecycle Management**.
* Centralized cleanup calls (`removeUser`, `removeSession`, `leaveRoom`) in `afterConnectionClosed` to strictly prevent **Memory Leaks**.

#### 4. Commands

* **`SelectCommand`**: Updated to switch the User Context to `PRIVATE` upon execution.
* **`LeaveCommand`**: Updated to reset the User Context back to `GLOBAL` and clean up targets.

#### 5. Testing (Quality Assurance)

* **Unit Tests**: comprehensive updates to `ChatServiceTest` and `UserRegistryTest` to align with the new Context architecture.
* **Integration Tests**: Fixed `CommandIntegrationTest` to correctly simulate the session initialization flow (Physical -> Logical -> Register).
* **Coverage**: Verified edge cases including Race Conditions, Memory Leaks, and Context Switching.

<img width="1269" height="430" alt="ChatService" src="https://github.com/user-attachments/assets/2f9f7b7c-676f-4e27-90f9-36fb227b3929" />
<img width="1314" height="459" alt="ChatWebSocketHandler" src="https://github.com/user-attachments/assets/baef7ac3-0aff-49d4-bb21-8f2ea4f02c85" />
<img width="1292" height="460" alt="CommandIntergration" src="https://github.com/user-attachments/assets/ce894ac4-94d6-45c5-82b8-0b84dc382530" />
<img width="1322" height="463" alt="LeaveCommand" src="https://github.com/user-attachments/assets/6757e3f5-7104-4670-b0f4-c4ce1e72033f" />
<img width="1275" height="460" alt="PrivateChatRegistryTest" src="https://github.com/user-attachments/assets/3a79204b-14fa-4301-960f-32ef0d552120" />
<img width="1319" height="469" alt="SelectCommand" src="https://github.com/user-attachments/assets/93ecbaa9-585c-4955-adc7-4eb36a0174ac" />
<img width="1295" height="580" alt="UserRegistry" src="https://github.com/user-attachments/assets/291f147e-418f-4ddb-8780-504c04711d88" />
