### PR TITLE
feat(US-6.3):Implement /join and refactor /leave with Context + Registry

### DIFF
--- a/src/main/java/org/example/VChatTalk/command/MessageConstants.java
+++ b/src/main/java/org/example/VChatTalk/command/MessageConstants.java
@@ -43,6 +43,10 @@ public class MessageConstants {
 
     public static final String ERR_INVALID_JSON = AnsiColor.RED + "Invalid message format." + AnsiColor.RESET;
 
+    public static final String ERR_ROOM_REQUIRED = AnsiColor.RED + "Room name is required. Usage: /join #room" + AnsiColor.RESET;
+
+    public static final String ERR_INVALID_ROOM_FORMAT = AnsiColor.RED + "Invalid room format. Room must start with '#' and contain a name. Example: /join #abc" + AnsiColor.RESET;
+
     // --- SYSTEM MESSAGES ---
     public static final String MSG_LOGIN_SUCCESS =
             AnsiColor.CYAN + "Welcome %s! You have joined the chat server." + AnsiColor.RESET;
@@ -70,5 +74,13 @@ public class MessageConstants {
 
     public static final String MSG_PRIVATE_CHAT_LEAVE =
             AnsiColor.GREEN + "You left private chat. Now in global chat." + BELL + AnsiColor.RESET;
+
+    // --- ROOM CHAT MESSAGES ---
+    public static final String MSG_ROOM_JOIN =
+            AnsiColor.GREEN + "Joined room: %s" + BELL + AnsiColor.RESET;
+
+    public static final String MSG_ROOM_LEAVE =
+            AnsiColor.GREEN + "You left the room. Now in global chat." + BELL + AnsiColor.RESET;
+
     private MessageConstants() {}
 }

--- a/src/main/java/org/example/VChatTalk/command/impl/JoinCommand.java
+++ b/src/main/java/org/example/VChatTalk/command/impl/JoinCommand.java
@@ -42,8 +42,13 @@ public class JoinCommand implements IChatCommand {
         }
 
         // Validate input: /join #room
-        String roomId = result.getArgument();
-        if (roomId == null || roomId.isBlank()) {
+        String argument = result.getArgument();
+        if (argument == null || argument.isBlank()) {
+            responder.sendError(session, MessageConstants.ERR_ROOM_REQUIRED);
+            return;
+        }
+        String roomId = argument.trim();
+        if (roomId.isEmpty()) {
             responder.sendError(session, MessageConstants.ERR_ROOM_REQUIRED);
             return;
         }

--- a/src/main/java/org/example/VChatTalk/command/impl/JoinCommand.java
+++ b/src/main/java/org/example/VChatTalk/command/impl/JoinCommand.java
@@ -42,8 +42,8 @@ public class JoinCommand implements IChatCommand {
         }
 
         // Validate input: /join #room
-        String roomId = result.getArgument().trim();
-        if (roomId.isEmpty()) {
+        String roomId = result.getArgument();
+        if (roomId == null || roomId.isBlank()) {
             responder.sendError(session, MessageConstants.ERR_ROOM_REQUIRED);
             return;
         }

--- a/src/main/java/org/example/VChatTalk/command/impl/JoinCommand.java
+++ b/src/main/java/org/example/VChatTalk/command/impl/JoinCommand.java
@@ -18,16 +18,15 @@ import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
-public class LeaveCommand implements IChatCommand {
-
+public class JoinCommand implements IChatCommand {
     private final UserRegistry userRegistry;
-    private final SystemResponseSender responder;
-    private final PrivateChatRegistry privateChatRegistry;
     private final RoomRegistry roomRegistry;
+    private final PrivateChatRegistry privateChatRegistry;
+    private final SystemResponseSender responder;
 
     @Override
     public CommandType getType() {
-        return CommandType.LEAVE;
+        return CommandType.JOIN;
     }
 
     @Override
@@ -35,32 +34,41 @@ public class LeaveCommand implements IChatCommand {
         String sessionId = session.getId();
         UserSession userSession = userRegistry.getSession(sessionId);
 
-        // 1️⃣ Auth check
+        // Auth check
         if (userSession == null ||
                 MessageConstants.USER_ANONYMOUS.equals(userSession.getUsername())) {
             responder.sendError(session, MessageConstants.ERR_NOT_LOGGED_IN);
             return;
         }
 
-        // 2️⃣ Context handling
+        // Validate input: /join #room
+        String roomId = result.getArgument().trim();
+        if (roomId.isEmpty()) {
+            responder.sendError(session, MessageConstants.ERR_ROOM_REQUIRED);
+            return;
+        }
+
+        if (!roomId.startsWith("#") || roomId.length() <= 1) {
+            responder.sendError(session, MessageConstants.ERR_INVALID_ROOM_FORMAT);
+            return;
+        }
+
         switch (userSession.getContext()) {
+            case PRIVATE -> privateChatRegistry.removeTarget(sessionId);
 
-            case ROOM -> {
-                roomRegistry.getRoomOfSession(sessionId).ifPresent(roomId -> roomRegistry.leaveRoom(roomId, sessionId));
-                userRegistry.updateContext(sessionId, ChatContext.GLOBAL);
-                responder.sendSystem(session, MessageConstants.MSG_ROOM_LEAVE);
-            }
-
-            case PRIVATE -> {
-                privateChatRegistry.removeTarget(sessionId);
-
-                userRegistry.updateContext(sessionId, ChatContext.GLOBAL);
-                responder.sendSystem(session, MessageConstants.MSG_PRIVATE_CHAT_LEAVE);
-            }
+            case ROOM -> roomRegistry.leaveCurrentRoom(sessionId);
 
             case GLOBAL -> {
-                responder.sendError(session, MessageConstants.ERR_ALREADY_IN_GLOBAL);
+                // no-op
             }
         }
+
+        roomRegistry.joinRoom(roomId, sessionId);
+
+        userRegistry.updateContext(sessionId, ChatContext.ROOM);
+
+        responder.sendSystem(session,
+                String.format(MessageConstants.MSG_ROOM_JOIN, roomId));
+
     }
 }

--- a/src/test/java/org/example/VChatTalk/command/CommandIntegrationTest.java
+++ b/src/test/java/org/example/VChatTalk/command/CommandIntegrationTest.java
@@ -50,7 +50,7 @@ class CommandIntegrationTest {
                 new SelectCommand(responder, userRegistry, privateChatRegistry),
                 new ListCommand(userRegistry, responder),
                 new HelpCommand(responder),
-                new LeaveCommand(userRegistry, responder, privateChatRegistry,roomRegistry),
+                new LeaveCommand(userRegistry, responder, privateChatRegistry, roomRegistry),
                 new ExitCommand(userRegistry, responder),
                 new UnknownCommand(responder)
         );

--- a/src/test/java/org/example/VChatTalk/command/CommandIntegrationTest.java
+++ b/src/test/java/org/example/VChatTalk/command/CommandIntegrationTest.java
@@ -2,10 +2,7 @@ package org.example.VChatTalk.command;
 
 import org.example.VChatTalk.command.impl.*;
 import org.example.VChatTalk.command.service.CommandParserService;
-import org.example.VChatTalk.util.PrivateChatRegistry;
-import org.example.VChatTalk.util.SessionRegistry;
-import org.example.VChatTalk.util.SystemResponseSender;
-import org.example.VChatTalk.util.UserRegistry;
+import org.example.VChatTalk.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +28,7 @@ class CommandIntegrationTest {
     private CommandParserService commandParser;
     private CommandExecutor commandExecutor;
     private SessionRegistry sessionRegistry;
+    private RoomRegistry roomRegistry;
 
     // --- Mocks (External Boundaries only) ---
     @Mock
@@ -43,6 +41,7 @@ class CommandIntegrationTest {
         commandParser = new CommandParserService();
         userRegistry = new UserRegistry();
         privateChatRegistry = new PrivateChatRegistry();
+        roomRegistry = new RoomRegistry();
 
         // 2. Wire up the Commands with the Real Registry
         List<IChatCommand> commands = Arrays.asList(
@@ -51,7 +50,7 @@ class CommandIntegrationTest {
                 new SelectCommand(responder, userRegistry, privateChatRegistry),
                 new ListCommand(userRegistry, responder),
                 new HelpCommand(responder),
-                new LeaveCommand(userRegistry, responder, privateChatRegistry),
+                new LeaveCommand(userRegistry, responder, privateChatRegistry,roomRegistry),
                 new ExitCommand(userRegistry, responder),
                 new UnknownCommand(responder)
         );

--- a/src/test/java/org/example/VChatTalk/command/impl/JoinCommandTest.java
+++ b/src/test/java/org/example/VChatTalk/command/impl/JoinCommandTest.java
@@ -1,0 +1,171 @@
+package org.example.VChatTalk.command.impl;
+
+import org.example.VChatTalk.command.CommandResult;
+import org.example.VChatTalk.command.CommandType;
+import org.example.VChatTalk.command.MessageConstants;
+import org.example.VChatTalk.model.ChatContext;
+import org.example.VChatTalk.model.UserSession;
+import org.example.VChatTalk.util.PrivateChatRegistry;
+import org.example.VChatTalk.util.RoomRegistry;
+import org.example.VChatTalk.util.SystemResponseSender;
+import org.example.VChatTalk.util.UserRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JoinCommandTest {
+
+    @Mock private UserRegistry userRegistry;
+    @Mock private RoomRegistry roomRegistry;
+    @Mock private PrivateChatRegistry privateChatRegistry;
+    @Mock private SystemResponseSender responder;
+    @Mock private WebSocketSession session;
+
+    private JoinCommand joinCommand;
+
+    private static final String SESSION_ID = "s1";
+    private static final String ROOM_ID = "#general";
+
+    @BeforeEach
+    void setUp() {
+        joinCommand = new JoinCommand(
+                userRegistry,
+                roomRegistry,
+                privateChatRegistry,
+                responder
+        );
+        when(session.getId()).thenReturn(SESSION_ID);
+    }
+
+    // ---------- helper ----------
+    private CommandResult joinCmd(String argument) {
+        return new CommandResult(CommandType.JOIN, argument, null);
+    }
+
+    // ---------- FAIL CASES ----------
+
+    @Test
+    @DisplayName("Fail: User not logged in -> ERR_NOT_LOGGED_IN")
+    void testExecute_NotLoggedIn() throws IOException {
+        when(userRegistry.getSession(SESSION_ID)).thenReturn(null);
+
+        joinCommand.execute(session, joinCmd(ROOM_ID));
+
+        verify(responder).sendError(session, MessageConstants.ERR_NOT_LOGGED_IN);
+        verifyNoInteractions(roomRegistry, privateChatRegistry);
+    }
+
+    @Test
+    @DisplayName("Fail: Room argument missing -> ERR_ROOM_REQUIRED")
+    void testExecute_RoomRequired() throws IOException {
+        UserSession userSession = UserSession.builder()
+                .sessionId(SESSION_ID)
+                .username("Alice")
+                .context(ChatContext.GLOBAL)
+                .build();
+
+        when(userRegistry.getSession(SESSION_ID)).thenReturn(userSession);
+
+        joinCommand.execute(session, joinCmd("   "));
+
+        verify(responder).sendError(session, MessageConstants.ERR_ROOM_REQUIRED);
+        verifyNoInteractions(roomRegistry, privateChatRegistry);
+    }
+
+    @Test
+    @DisplayName("Fail: Invalid room format -> ERR_INVALID_ROOM_FORMAT")
+    void testExecute_InvalidRoomFormat() throws IOException {
+        UserSession userSession = UserSession.builder()
+                .sessionId(SESSION_ID)
+                .username("Alice")
+                .context(ChatContext.GLOBAL)
+                .build();
+
+        when(userRegistry.getSession(SESSION_ID)).thenReturn(userSession);
+
+        joinCommand.execute(session, joinCmd("room1"));
+
+        verify(responder).sendError(session, MessageConstants.ERR_INVALID_ROOM_FORMAT);
+        verifyNoInteractions(roomRegistry, privateChatRegistry);
+    }
+
+    // ---------- SUCCESS CASES ----------
+
+    @Test
+    @DisplayName("Success: Join room from GLOBAL context")
+    void testExecute_JoinFromGlobal() throws IOException {
+        UserSession globalSession = UserSession.builder()
+                .sessionId(SESSION_ID)
+                .username("Alice")
+                .context(ChatContext.GLOBAL)
+                .build();
+
+        when(userRegistry.getSession(SESSION_ID)).thenReturn(globalSession);
+
+        joinCommand.execute(session, joinCmd(ROOM_ID));
+
+        verify(roomRegistry).joinRoom(ROOM_ID, SESSION_ID);
+        verify(userRegistry).updateContext(SESSION_ID, ChatContext.ROOM);
+        verify(responder).sendSystem(
+                session,
+                String.format(MessageConstants.MSG_ROOM_JOIN, ROOM_ID)
+        );
+
+        verifyNoInteractions(privateChatRegistry);
+    }
+
+    @Test
+    @DisplayName("Success: Join room from PRIVATE context (auto leave private)")
+    void testExecute_JoinFromPrivate() throws IOException {
+        UserSession privateSession = UserSession.builder()
+                .sessionId(SESSION_ID)
+                .username("Alice")
+                .context(ChatContext.PRIVATE)
+                .build();
+
+        when(userRegistry.getSession(SESSION_ID)).thenReturn(privateSession);
+
+        joinCommand.execute(session, joinCmd(ROOM_ID));
+
+        verify(privateChatRegistry).removeTarget(SESSION_ID);
+        verify(roomRegistry).joinRoom(ROOM_ID, SESSION_ID);
+        verify(userRegistry).updateContext(SESSION_ID, ChatContext.ROOM);
+        verify(responder).sendSystem(
+                session,
+                String.format(MessageConstants.MSG_ROOM_JOIN, ROOM_ID)
+        );
+    }
+
+    @Test
+    @DisplayName("Success: Switch room from ROOM context (auto leave current room)")
+    void testExecute_SwitchRoom() throws IOException {
+        UserSession roomSession = UserSession.builder()
+                .sessionId(SESSION_ID)
+                .username("Alice")
+                .context(ChatContext.ROOM)
+                .build();
+
+        when(userRegistry.getSession(SESSION_ID)).thenReturn(roomSession);
+
+        joinCommand.execute(session, joinCmd(ROOM_ID));
+
+        verify(roomRegistry).leaveCurrentRoom(SESSION_ID);
+        verify(roomRegistry).joinRoom(ROOM_ID, SESSION_ID);
+        verify(userRegistry).updateContext(SESSION_ID, ChatContext.ROOM);
+        verify(responder).sendSystem(
+                session,
+                String.format(MessageConstants.MSG_ROOM_JOIN, ROOM_ID)
+        );
+
+        verifyNoInteractions(privateChatRegistry);
+    }
+}

--- a/src/test/java/org/example/VChatTalk/command/impl/JoinCommandTest.java
+++ b/src/test/java/org/example/VChatTalk/command/impl/JoinCommandTest.java
@@ -75,7 +75,7 @@ class JoinCommandTest {
 
         when(userRegistry.getSession(SESSION_ID)).thenReturn(userSession);
 
-        joinCommand.execute(session, joinCmd("   "));
+        joinCommand.execute(session, joinCmd(null));
 
         verify(responder).sendError(session, MessageConstants.ERR_ROOM_REQUIRED);
         verifyNoInteractions(roomRegistry, privateChatRegistry);
@@ -167,5 +167,21 @@ class JoinCommandTest {
         );
 
         verifyNoInteractions(privateChatRegistry);
+    }
+    @Test
+    @DisplayName("Fail: Room argument is blank -> ERR_ROOM_REQUIRED")
+    void testExecute_RoomArgumentBlank() throws IOException {
+        UserSession userSession = UserSession.builder()
+                .sessionId(SESSION_ID)
+                .username("Alice")
+                .context(ChatContext.GLOBAL)
+                .build();
+
+        when(userRegistry.getSession(SESSION_ID)).thenReturn(userSession);
+
+        joinCommand.execute(session, joinCmd("   "));
+
+        verify(responder).sendError(session, MessageConstants.ERR_ROOM_REQUIRED);
+        verifyNoInteractions(roomRegistry, privateChatRegistry);
     }
 }

--- a/src/test/java/org/example/VChatTalk/command/impl/LeaveCommandTest.java
+++ b/src/test/java/org/example/VChatTalk/command/impl/LeaveCommandTest.java
@@ -6,6 +6,7 @@ import org.example.VChatTalk.command.MessageConstants;
 import org.example.VChatTalk.model.ChatContext;
 import org.example.VChatTalk.model.UserSession;
 import org.example.VChatTalk.util.PrivateChatRegistry;
+import org.example.VChatTalk.util.RoomRegistry;
 import org.example.VChatTalk.util.SystemResponseSender;
 import org.example.VChatTalk.util.UserRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import static org.mockito.Mockito.*;
 
@@ -27,20 +29,28 @@ class LeaveCommandTest {
     @Mock private SystemResponseSender responder;
     @Mock private WebSocketSession session;
     @Mock private PrivateChatRegistry privateChatRegistry;
+    @Mock private RoomRegistry roomRegistry;
 
     private LeaveCommand leaveCommand;
+
     private static final String SESSION_ID = "s1";
+    private static final String ROOM_ID = "#general";
 
     @BeforeEach
     void setUp() {
-        leaveCommand = new LeaveCommand(userRegistry, responder, privateChatRegistry);
+        leaveCommand = new LeaveCommand(
+                userRegistry,
+                responder,
+                privateChatRegistry,
+                roomRegistry
+        );
         lenient().when(session.getId()).thenReturn(SESSION_ID);
     }
 
     @Test
     @DisplayName("Fail: User not logged in -> ERR_NOT_LOGGED_IN")
     void testExecute_NotLoggedIn() throws IOException {
-        // Arrange: user chưa login
+        // Arrange: user not logged in
         when(userRegistry.getSession(SESSION_ID)).thenReturn(null);
 
         // Act
@@ -48,7 +58,7 @@ class LeaveCommandTest {
 
         // Assert
         verify(responder).sendError(session, MessageConstants.ERR_NOT_LOGGED_IN);
-        verifyNoInteractions(privateChatRegistry);
+        verifyNoInteractions(privateChatRegistry, roomRegistry);
     }
 
     @Test
@@ -65,7 +75,7 @@ class LeaveCommandTest {
         leaveCommand.execute(session, new CommandResult(CommandType.LEAVE, null, null));
 
         verify(responder).sendError(session, MessageConstants.ERR_ALREADY_IN_GLOBAL);
-        verify(privateChatRegistry, never()).removeTarget(anyString());
+        verifyNoInteractions(privateChatRegistry, roomRegistry);
         verify(userRegistry, never()).updateContext(any(), any());
     }
 
@@ -90,5 +100,48 @@ class LeaveCommandTest {
 
         // 3️⃣ Feedback sent
         verify(responder).sendSystem(session, MessageConstants.MSG_PRIVATE_CHAT_LEAVE);
+        verifyNoInteractions(roomRegistry);
+    }
+
+    @Test
+    @DisplayName("Success: Leave ROOM chat")
+    void testExecute_LeaveRoom() throws IOException {
+        UserSession roomSession = UserSession.builder()
+                .sessionId(SESSION_ID)
+                .username("Alice")
+                .context(ChatContext.ROOM)
+                .build();
+
+        when(userRegistry.getSession(SESSION_ID)).thenReturn(roomSession);
+        when(roomRegistry.getRoomOfSession(SESSION_ID))
+                .thenReturn(Optional.of(ROOM_ID));
+
+        leaveCommand.execute(session, new CommandResult(CommandType.LEAVE, null, null));
+
+        verify(roomRegistry).leaveRoom(ROOM_ID, SESSION_ID);
+        verify(userRegistry).updateContext(SESSION_ID, ChatContext.GLOBAL);
+        verify(responder).sendSystem(session, MessageConstants.MSG_ROOM_LEAVE);
+        verifyNoInteractions(privateChatRegistry);
+    }
+
+    @Test
+    @DisplayName("Edge case: Context is ROOM but no room found in registry")
+    void testExecute_RoomContextButNoRoomFound() throws IOException {
+        UserSession roomSession = UserSession.builder()
+                .sessionId(SESSION_ID)
+                .username("Alice")
+                .context(ChatContext.ROOM)
+                .build();
+
+        when(userRegistry.getSession(SESSION_ID)).thenReturn(roomSession);
+        when(roomRegistry.getRoomOfSession(SESSION_ID))
+                .thenReturn(Optional.empty());
+
+        leaveCommand.execute(session, new CommandResult(CommandType.LEAVE, null, null));
+
+        verify(roomRegistry, never()).leaveRoom(any(), any());
+        verify(userRegistry).updateContext(SESSION_ID, ChatContext.GLOBAL);
+        verify(responder).sendSystem(session, MessageConstants.MSG_ROOM_LEAVE);
+        verifyNoInteractions(privateChatRegistry);
     }
 }


### PR DESCRIPTION
## Summary
This pull request implements the `/join` command and refactors the `/leave` command using the new **Context + Registry** model.

## Key Changes
- Implemented context-aware `/join` command with automatic context switching:
  - Leaves private chat when joining a room
  - Leaves the current room before joining a new room
- Refactored `/leave` command to correctly handle:
  - ROOM context (leave current room and return to GLOBAL)
  - PRIVATE context (leave private chat and return to GLOBAL)
- Updated and added unit tests to ensure correct behavior across contexts

## Acceptance Criteria
- [x] `/join` automatically handles context switching (e.g. PRIVATE → ROOM, ROOM → ROOM)
- [x] `/leave` works correctly for both ROOM and PRIVATE contexts
- [x] User context is updated consistently via the Context + Registry model
