### PR TITLE
US-6.4 Refactor/Centralize ChatService Routing Logic

### DIFF
--- a/src/main/java/org/example/VChatTalk/service/BroadcastService.java
+++ b/src/main/java/org/example/VChatTalk/service/BroadcastService.java
@@ -67,4 +67,43 @@ public class BroadcastService {
             session.sendMessage(new TextMessage(json));
         }
     }
+    /**
+     * Broadcast a message to all members of a room.
+     *
+     * @param dto        Message to send
+     * @param sessionIds Session IDs of room members
+     */
+    public void broadcastToRoom(MessageDTO dto, Collection<String> sessionIds, String senderSessionId) {
+        try {
+            String json = mapper.writeValueAsString(dto);
+            int successCount = 0;
+
+            for (String sessionId : sessionIds) {
+
+                if (sessionId.equals(senderSessionId)) {
+                    continue;
+                }
+
+                WebSocketSession session = sessionRegistry.findSessionById(sessionId);
+                if (session == null || !session.isOpen()) {
+                    continue;
+                }
+
+                try {
+                    session.sendMessage(new TextMessage(json));
+                    successCount++;
+                } catch (IOException e) {
+                    log.warn("[ROOM_BROADCAST_FAILED] sessionId={}", sessionId);
+                }
+            }
+
+            log.info("[ROOM_BROADCAST] Room message from [{}] -> {} clients",
+                    dto.getSender(), successCount);
+
+        } catch (IOException e) {
+            log.error("[ROOM_BROADCAST_ERROR] {}", e.getMessage());
+        }
+    }
+
+
 }

--- a/src/main/java/org/example/VChatTalk/service/BroadcastService.java
+++ b/src/main/java/org/example/VChatTalk/service/BroadcastService.java
@@ -67,11 +67,12 @@ public class BroadcastService {
             session.sendMessage(new TextMessage(json));
         }
     }
+
     /**
      * Broadcast a message to all members of a room.
-     *
-     * @param dto        Message to send
-     * @param sessionIds Session IDs of room members
+     * @param dto             Message to send
+     * @param sessionIds      Session IDs of room members
+     * @param senderSessionId Session ID of the sender (excluded from broadcast)
      */
     public void broadcastToRoom(MessageDTO dto, Collection<String> sessionIds, String senderSessionId) {
         try {
@@ -104,6 +105,5 @@ public class BroadcastService {
             log.error("[ROOM_BROADCAST_ERROR] {}", e.getMessage());
         }
     }
-
 
 }

--- a/src/main/java/org/example/VChatTalk/service/ChatService.java
+++ b/src/main/java/org/example/VChatTalk/service/ChatService.java
@@ -8,12 +8,11 @@
     import org.example.VChatTalk.model.UserSession;
     import org.example.VChatTalk.util.AnsiColor;
     import org.example.VChatTalk.util.PrivateChatRegistry;
+    import org.example.VChatTalk.util.RoomRegistry;
     import org.example.VChatTalk.util.SessionRegistry;
     import org.example.VChatTalk.util.UserRegistry;
     import org.springframework.stereotype.Service;
     import org.springframework.web.socket.WebSocketSession;
-    import org.example.VChatTalk.util.RoomRegistry;
-
 
     import java.io.IOException;
     import java.time.Instant;
@@ -80,7 +79,8 @@
                     }
                 }
                 case ROOM -> {
-                    String roomId = roomRegistry.getRoomOfSession(sessionId).orElseThrow();
+                    String roomId = roomRegistry.getRoomOfSession(sessionId)
+                            .orElseThrow(() -> new IllegalStateException("User is in ROOM context but not assigned to any room"));
                     handleRoomMessage(sender, message, roomId);
                 }
                 case GLOBAL -> broadcastService.broadcast(message, senderSession);

--- a/src/main/java/org/example/VChatTalk/service/ChatService.java
+++ b/src/main/java/org/example/VChatTalk/service/ChatService.java
@@ -12,6 +12,8 @@
     import org.example.VChatTalk.util.UserRegistry;
     import org.springframework.stereotype.Service;
     import org.springframework.web.socket.WebSocketSession;
+    import org.example.VChatTalk.util.RoomRegistry;
+
 
     import java.io.IOException;
     import java.time.Instant;
@@ -29,6 +31,7 @@
         private final UserRegistry userRegistry;
         private final PrivateChatRegistry privateChatRegistry;
         private final BroadcastService broadcastService;
+        private final RoomRegistry roomRegistry;
 
         // ========== MESSAGE ROUTING ==========
         private void recoverFromBrokenPrivateContext(WebSocketSession session, String sessionId)
@@ -76,7 +79,10 @@
                         recoverFromBrokenPrivateContext(senderSession, sessionId);
                     }
                 }
-                case ROOM -> handleRoomMessage(senderSession, message);
+                case ROOM -> {
+                    String roomId = roomRegistry.getRoomOfSession(sessionId).orElseThrow();
+                    handleRoomMessage(sender, message, roomId);
+                }
                 case GLOBAL -> broadcastService.broadcast(message, senderSession);
             }
         }
@@ -199,8 +205,14 @@
         /**
          * Handles broadcasting a message to a specific room.
          */
-        private void handleRoomMessage(WebSocketSession senderSession, MessageDTO message) throws IOException {
-            // 🟡 TODO: Update and Uncomment when RoomRegistry is ready
+        private void handleRoomMessage(UserSession sender, MessageDTO message, String roomId) throws IOException {
+            var members = roomRegistry.getRoomMembers(roomId);
+            if (members.isEmpty()) {
+                log.warn("Room {} has no members", roomId);
+                return;
+            }
+
+            broadcastService.broadcastToRoom(message, members, sender.getSessionId());
         }
 
         /**

--- a/src/test/java/org/example/VChatTalk/service/BroadcastServiceTest.java
+++ b/src/test/java/org/example/VChatTalk/service/BroadcastServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import static org.mockito.Mockito.*;
 
@@ -121,5 +122,97 @@ class BroadcastServiceTest {
         // Assert
         verify(sessionA).sendMessage(any(TextMessage.class)); // Attempted
         verify(sessionB).sendMessage(any(TextMessage.class)); // Still executed
+    }
+    @Test
+    @DisplayName("broadcastToRoom - should send to all room members except sender")
+    void broadcastToRoom_excludeSender() throws IOException {
+        WebSocketSession memberA = mock(WebSocketSession.class);
+        WebSocketSession memberB = mock(WebSocketSession.class);
+
+        when(memberA.isOpen()).thenReturn(true);
+        when(memberB.isOpen()).thenReturn(true);
+
+        when(sessionRegistry.findSessionById("A")).thenReturn(memberA);
+        when(sessionRegistry.findSessionById("B")).thenReturn(memberB);
+
+        MessageDTO msg = MessageDTO.builder()
+                .type(MessageType.MESSAGE)
+                .sender("Alice")
+                .content("Hello Room")
+                .build();
+
+        broadcastService.broadcastToRoom(
+                msg,
+                Set.of("sender", "A", "B"),
+                "sender"
+        );
+
+        verify(memberA).sendMessage(any());
+        verify(memberB).sendMessage(any());
+    }
+
+    @Test
+    @DisplayName("broadcastToRoom - should do nothing when room has no members")
+    void broadcastToRoom_emptyRoom() throws IOException {
+        MessageDTO msg = MessageDTO.builder()
+                .type(MessageType.MESSAGE)
+                .content("Hello")
+                .build();
+
+        broadcastService.broadcastToRoom(msg, Set.of(), "sender");
+
+        verifyNoInteractions(sessionRegistry);
+    }
+
+    @Test
+    @DisplayName("broadcastToRoom - should skip closed sessions")
+    void broadcastToRoom_skipClosedSession() throws IOException {
+        WebSocketSession member = mock(WebSocketSession.class);
+
+        when(member.isOpen()).thenReturn(false);
+        when(sessionRegistry.findSessionById("A")).thenReturn(member);
+
+        MessageDTO msg = MessageDTO.builder()
+                .type(MessageType.MESSAGE)
+                .content("Hello")
+                .build();
+
+        broadcastService.broadcastToRoom(
+                msg,
+                Set.of("A"),
+                "sender"
+        );
+
+        verify(member, never()).sendMessage(any());
+    }
+
+    @Test
+    @DisplayName("broadcastToRoom - should continue if one session fails")
+    void broadcastToRoom_continueOnFailure() throws IOException {
+        WebSocketSession memberA = mock(WebSocketSession.class);
+        WebSocketSession memberB = mock(WebSocketSession.class);
+
+        when(memberA.isOpen()).thenReturn(true);
+        when(memberB.isOpen()).thenReturn(true);
+
+        when(sessionRegistry.findSessionById("A")).thenReturn(memberA);
+        when(sessionRegistry.findSessionById("B")).thenReturn(memberB);
+
+        doThrow(new IOException("IO error"))
+                .when(memberA).sendMessage(any());
+
+        MessageDTO msg = MessageDTO.builder()
+                .type(MessageType.MESSAGE)
+                .content("Hello")
+                .build();
+
+        broadcastService.broadcastToRoom(
+                msg,
+                Set.of("A", "B"),
+                "sender"
+        );
+
+        verify(memberA).sendMessage(any());
+        verify(memberB).sendMessage(any());
     }
 }

--- a/src/test/java/org/example/VChatTalk/service/ChatServiceTest.java
+++ b/src/test/java/org/example/VChatTalk/service/ChatServiceTest.java
@@ -5,6 +5,7 @@ import org.example.VChatTalk.model.MessageDTO;
 import org.example.VChatTalk.model.MessageType;
 import org.example.VChatTalk.model.UserSession;
 import org.example.VChatTalk.util.PrivateChatRegistry;
+import org.example.VChatTalk.util.RoomRegistry;
 import org.example.VChatTalk.util.SessionRegistry;
 import org.example.VChatTalk.util.UserRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +19,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -30,6 +33,7 @@ class ChatServiceTest {
     @Mock private PrivateChatRegistry privateChatRegistry;
     @Mock private BroadcastService broadcastService;
     @Mock private WebSocketSession senderSession;
+    @Mock private RoomRegistry roomRegistry;
 
     @InjectMocks
     private ChatService chatService;
@@ -152,4 +156,66 @@ class ChatServiceTest {
 
         assertThrows(IllegalStateException.class, () -> chatService.handleMessage(SENDER_ID, dto));
     }
+    @Test
+    @DisplayName("Route - ROOM with no members should NOT broadcast")
+    void routeMessage_RoomMode_NoMembers() throws IOException {
+        String roomId = "room-1";
+
+        MessageDTO dto = MessageDTO.builder()
+                .content("hello room")
+                .build();
+
+        UserSession roomSession = UserSession.builder()
+                .sessionId(SENDER_ID)
+                .username(SENDER_NAME)
+                .context(ChatContext.ROOM)
+                .build();
+
+        when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
+        when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
+        when(userRegistry.getSession(SENDER_ID)).thenReturn(roomSession);
+
+        when(roomRegistry.getRoomOfSession(SENDER_ID))
+                .thenReturn(Optional.of(roomId));
+
+        chatService.routeMessage(senderSession, dto);
+
+        verify(broadcastService, never()).broadcastToRoom(any(), anyCollection(), anyString());
+    }
+    @Test
+    @DisplayName("Route - ROOM context but no room assigned should throw exception")
+    void routeMessage_RoomMode_NoRoom() {
+        // given
+        UserSession roomUser = UserSession.builder()
+                .sessionId(SENDER_ID)
+                .username(SENDER_NAME)
+                .context(ChatContext.ROOM)
+                .build();
+
+        when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
+        when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
+        when(userRegistry.getSession(SENDER_ID)).thenReturn(roomUser);
+
+        when(roomRegistry.getRoomOfSession(SENDER_ID))
+                .thenReturn(Optional.empty());
+
+        MessageDTO dto = MessageDTO.builder()
+                .content("hello room")
+                .build();
+
+        // when + then
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> chatService.routeMessage(senderSession, dto)
+        );
+
+        assertEquals(
+                "User is in ROOM context but not assigned to any room",
+                ex.getMessage()
+        );
+
+        verify(broadcastService, never())
+                .broadcastToRoom(any(), any(), any());
+    }
+
 }


### PR DESCRIPTION
Description

Summary: Centralize routing logic in ChatService using Context.
Priority: High | Points: 5
Component: Service Layer

Technical Implementation:

Refactor routeMessage:



UserSession sender = userRegistry.getSession(sessionId);
switch (sender.getContext()) {
    case PRIVATE -> {
        String target = privateChatRegistry.getTarget(sessionId); // Keep using Registry
        handlePrivateMessage(sender, message, target);
    }
    case ROOM -> {
        String roomId = roomRegistry.getRoomOfSession(sessionId).orElseThrow();
        handleRoomMessage(sender, message, roomId);
    }
    case GLOBAL -> broadcastService.broadcast(message, sender.getSession());
}
handleRoomMessage:

Fetch members: roomRegistry.getRoomMembers(roomId).

Delegate to BroadcastService.

Acceptance Criteria:
[ ] Routing depends on UserSession.getContext().
[ ] Data retrieval depends on specific Registries (SRP).