### PR TITLE
US-6.5: Implement targeted room broadcast feature

### DIFF
--- a/src/main/java/org/example/VChatTalk/VChatTalkApplication.java
+++ b/src/main/java/org/example/VChatTalk/VChatTalkApplication.java
@@ -9,5 +9,4 @@ public class VChatTalkApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(VChatTalkApplication.class, args);
 	}
-
 }

--- a/src/main/java/org/example/VChatTalk/service/BroadcastService.java
+++ b/src/main/java/org/example/VChatTalk/service/BroadcastService.java
@@ -110,12 +110,26 @@ public class BroadcastService {
      * Broadcast message to a specific set of target sessions (e.g. room members or private chat).
      * Formats message if it belongs to a room context.
      *
-     * @param dto        message to send
-     * @param sessionIds target session IDs
+     * <p>
+     * This method sends the message to all provided {@code sessionIds}, including the sender
+     * if their session ID is present in the collection. Callers are responsible for excluding
+     * the sender from {@code sessionIds} if they do not want the sender to receive the message.
+     * This differs from {@link #broadcastToRoom(MessageDTO, Collection, String)} which always
+     * excludes the sender based on {@code senderSessionId}.
+     * </p>
+     *
+     * @param dto        message to send (must have non-null sender and content)
+     * @param sessionIds target session IDs (may include the sender)
      */
     public void broadcastToTargets(MessageDTO dto, Collection<String> sessionIds) {
         if (sessionIds == null || sessionIds.isEmpty()) {
-            log.debug("[BROADCAST_TO_TARGETS] No sessions provided.");
+            log.debug("[BROADCAST_TO_TARGETS] No sessionIds provided. Skipping broadcast.");
+            return;
+        }
+
+        // Defensive null check for dto and core fields
+        if (dto == null || dto.getSender() == null || dto.getContent() == null) {
+            log.warn("[BROADCAST_TO_TARGETS] Invalid message: missing sender or content. Skipped.");
             return;
         }
 
@@ -127,33 +141,37 @@ public class BroadcastService {
                         dto.getRoomId(), dto.getSender(), dto.getContent());
             }
 
+            // Prepare serialized copy
             MessageDTO formattedDto = MessageDTO.builder()
                     .type(dto.getType())
                     .sender(dto.getSender())
                     .content(formattedContent)
-                    .timestamp(dto.getTimestamp())
                     .roomId(dto.getRoomId())
+                    .timestamp(dto.getTimestamp())
                     .build();
 
             String json = mapper.writeValueAsString(formattedDto);
             int successCount = 0;
 
-            for (String id : sessionIds) {
-                WebSocketSession session = sessionRegistry.findSessionById(id);
-                if (session == null || !session.isOpen()) continue;
+            for (String sessionId : sessionIds) {
+                WebSocketSession session = sessionRegistry.findSessionById(sessionId);
+
+                if (session == null || !session.isOpen()) {
+                    continue;
+                }
 
                 try {
                     session.sendMessage(new TextMessage(json));
                     successCount++;
                 } catch (IOException e) {
-                    log.warn("[BROADCAST_TO_TARGETS_FAILED] sessionId={} - {}", id, e.getMessage());
+                    log.warn("[BROADCAST_TO_TARGETS_FAILED] sessionId={} - {}", sessionId, e.getMessage());
                 }
             }
 
-            log.info("[BROADCAST_TO_TARGETS] Sender: [{}] -> {} sessions",
-                    dto.getSender(), successCount);
+            log.info("[BROADCAST_TO_TARGETS] Sender: [{}] -> {} sessions", dto.getSender(), successCount);
         } catch (IOException e) {
             log.error("[BROADCAST_TO_TARGETS_ERROR] {}", e.getMessage());
         }
     }
+
 }

--- a/src/main/java/org/example/VChatTalk/service/BroadcastService.java
+++ b/src/main/java/org/example/VChatTalk/service/BroadcastService.java
@@ -106,4 +106,54 @@ public class BroadcastService {
         }
     }
 
+    /**
+     * Broadcast message to a specific set of target sessions (e.g. room members or private chat).
+     * Formats message if it belongs to a room context.
+     *
+     * @param dto        message to send
+     * @param sessionIds target session IDs
+     */
+    public void broadcastToTargets(MessageDTO dto, Collection<String> sessionIds) {
+        if (sessionIds == null || sessionIds.isEmpty()) {
+            log.debug("[BROADCAST_TO_TARGETS] No sessions provided.");
+            return;
+        }
+
+        try {
+            // Format message for room if applicable
+            String formattedContent = dto.getContent();
+            if (dto.getRoomId() != null && dto.getRoomId().startsWith("#")) {
+                formattedContent = String.format("[%s] %s: %s",
+                        dto.getRoomId(), dto.getSender(), dto.getContent());
+            }
+
+            MessageDTO formattedDto = MessageDTO.builder()
+                    .type(dto.getType())
+                    .sender(dto.getSender())
+                    .content(formattedContent)
+                    .timestamp(dto.getTimestamp())
+                    .roomId(dto.getRoomId())
+                    .build();
+
+            String json = mapper.writeValueAsString(formattedDto);
+            int successCount = 0;
+
+            for (String id : sessionIds) {
+                WebSocketSession session = sessionRegistry.findSessionById(id);
+                if (session == null || !session.isOpen()) continue;
+
+                try {
+                    session.sendMessage(new TextMessage(json));
+                    successCount++;
+                } catch (IOException e) {
+                    log.warn("[BROADCAST_TO_TARGETS_FAILED] sessionId={} - {}", id, e.getMessage());
+                }
+            }
+
+            log.info("[BROADCAST_TO_TARGETS] Sender: [{}] -> {} sessions",
+                    dto.getSender(), successCount);
+        } catch (IOException e) {
+            log.error("[BROADCAST_TO_TARGETS_ERROR] {}", e.getMessage());
+        }
+    }
 }

--- a/src/test/java/org/example/VChatTalk/service/BroadcastServiceTest.java
+++ b/src/test/java/org/example/VChatTalk/service/BroadcastServiceTest.java
@@ -314,5 +314,26 @@ class BroadcastServiceTest {
 
         verifyNoInteractions(sessionRegistry);
     }
+    @Test
+    @DisplayName("broadcastToTargets - should send unformatted message when not in room context and skip null sessions")
+    void broadcastToTargets_unformattedAndSkipNullSessions() throws IOException {
+        WebSocketSession validSession = mock(WebSocketSession.class);
+        when(validSession.isOpen()).thenReturn(true);
+        when(sessionRegistry.findSessionById("S1")).thenReturn(validSession);
+        when(sessionRegistry.findSessionById("S2")).thenReturn(null); // simulate stale session
+
+        MessageDTO dto = MessageDTO.builder()
+                .type(MessageType.MESSAGE)
+                .sender("UserX")
+                .content("Direct message")
+                .roomId("private-123") // not a room context
+                .build();
+
+        broadcastService.broadcastToTargets(dto, Set.of("S1", "S2"));
+
+        String expectedJson = mapper.writeValueAsString(dto);
+        verify(validSession).sendMessage(new TextMessage(expectedJson));
+    }
+
 
 }

--- a/src/test/java/org/example/VChatTalk/service/BroadcastServiceTest.java
+++ b/src/test/java/org/example/VChatTalk/service/BroadcastServiceTest.java
@@ -215,4 +215,104 @@ class BroadcastServiceTest {
         verify(memberA).sendMessage(any());
         verify(memberB).sendMessage(any());
     }
+
+    // ========== US-6.5 ADDITIONAL TESTS ==========
+    @Test
+    @DisplayName("broadcastToTargets - should send formatted room message to all target sessions")
+    void broadcastToTargets_sendToAllTargets() throws IOException {
+        WebSocketSession session1 = mock(WebSocketSession.class);
+        WebSocketSession session2 = mock(WebSocketSession.class);
+
+        when(session1.isOpen()).thenReturn(true);
+        when(session2.isOpen()).thenReturn(true);
+        when(sessionRegistry.findSessionById("S1")).thenReturn(session1);
+        when(sessionRegistry.findSessionById("S2")).thenReturn(session2);
+
+        MessageDTO dto = MessageDTO.builder()
+                .type(MessageType.MESSAGE)
+                .sender("UserA")
+                .content("Hello team")
+                .roomId("#team-room")
+                .build();
+
+        broadcastService.broadcastToTargets(dto, Set.of("S1", "S2"));
+
+        String expectedJson = mapper.writeValueAsString(
+                MessageDTO.builder()
+                        .type(MessageType.MESSAGE)
+                        .sender("UserA")
+                        .content("[#team-room] UserA: Hello team")
+                        .roomId("#team-room")
+                        .build()
+        );
+
+        verify(session1).sendMessage(new TextMessage(expectedJson));
+        verify(session2).sendMessage(new TextMessage(expectedJson));
+    }
+
+    @Test
+    @DisplayName("broadcastToTargets - should skip closed sessions and continue sending others")
+    void broadcastToTargets_skipClosedSessions() throws IOException {
+        WebSocketSession closedSession = mock(WebSocketSession.class);
+        WebSocketSession openSession = mock(WebSocketSession.class);
+
+        when(closedSession.isOpen()).thenReturn(false);
+        when(openSession.isOpen()).thenReturn(true);
+        when(sessionRegistry.findSessionById("S1")).thenReturn(closedSession);
+        when(sessionRegistry.findSessionById("S2")).thenReturn(openSession);
+
+        MessageDTO dto = MessageDTO.builder()
+                .type(MessageType.MESSAGE)
+                .sender("UserB")
+                .content("Message to active sessions")
+                .roomId("#dev-room")
+                .build();
+
+        broadcastService.broadcastToTargets(dto, Set.of("S1", "S2"));
+
+        verify(closedSession, never()).sendMessage(any());
+        verify(openSession, times(1)).sendMessage(any());
+    }
+
+    @Test
+    @DisplayName("broadcastToTargets - should continue even if one session throws IOException")
+    void broadcastToTargets_continueWhenIOExceptionOccurs() throws IOException {
+        WebSocketSession faultySession = mock(WebSocketSession.class);
+        WebSocketSession validSession = mock(WebSocketSession.class);
+
+        when(faultySession.isOpen()).thenReturn(true);
+        when(validSession.isOpen()).thenReturn(true);
+        when(sessionRegistry.findSessionById("A")).thenReturn(faultySession);
+        when(sessionRegistry.findSessionById("B")).thenReturn(validSession);
+
+        doThrow(new IOException("Simulated failure")).when(faultySession).sendMessage(any());
+
+        MessageDTO dto = MessageDTO.builder()
+                .type(MessageType.MESSAGE)
+                .sender("UserC")
+                .content("Testing broadcast with one failure")
+                .roomId("#test-room")
+                .build();
+
+        broadcastService.broadcastToTargets(dto, Set.of("A", "B"));
+
+        verify(faultySession).sendMessage(any()); // attempted
+        verify(validSession).sendMessage(any());  // still delivered
+    }
+
+    @Test
+    @DisplayName("broadcastToTargets - should do nothing when sessionIds list is empty")
+    void broadcastToTargets_emptySessionList() {
+        MessageDTO dto = MessageDTO.builder()
+                .type(MessageType.MESSAGE)
+                .sender("System")
+                .content("No sessions to send")
+                .roomId("#empty-room")
+                .build();
+
+        broadcastService.broadcastToTargets(dto, Set.of());
+
+        verifyNoInteractions(sessionRegistry);
+    }
+
 }

--- a/src/test/java/org/example/VChatTalk/service/BroadcastServiceTest.java
+++ b/src/test/java/org/example/VChatTalk/service/BroadcastServiceTest.java
@@ -334,6 +334,37 @@ class BroadcastServiceTest {
         String expectedJson = mapper.writeValueAsString(dto);
         verify(validSession).sendMessage(new TextMessage(expectedJson));
     }
+    @Test
+    @DisplayName("broadcastToTargets - should send unformatted message when roomId is null or not starting with #")
+    void broadcastToTargets_sendUnformattedMessage_whenNoRoomId() throws IOException {
+        WebSocketSession session = mock(WebSocketSession.class);
+        when(session.isOpen()).thenReturn(true);
+        when(sessionRegistry.findSessionById("S1")).thenReturn(session);
 
+        // case 1: roomId is null
+        MessageDTO dtoWithoutRoom = MessageDTO.builder()
+                .type(MessageType.MESSAGE)
+                .sender("UserZ")
+                .content("General message")
+                .roomId(null)
+                .build();
 
+        broadcastService.broadcastToTargets(dtoWithoutRoom, Set.of("S1"));
+
+        String expectedJson1 = mapper.writeValueAsString(dtoWithoutRoom);
+        verify(session, times(1)).sendMessage(new TextMessage(expectedJson1));
+
+        // case 2: roomId does not start with '#'
+        MessageDTO dtoNonRoom = MessageDTO.builder()
+                .type(MessageType.MESSAGE)
+                .sender("UserZ")
+                .content("Private message")
+                .roomId("dev-room")
+                .build();
+
+        broadcastService.broadcastToTargets(dtoNonRoom, Set.of("S1"));
+
+        String expectedJson2 = mapper.writeValueAsString(dtoNonRoom);
+        verify(session, times(1)).sendMessage(new TextMessage(expectedJson2));
+    }
 }


### PR DESCRIPTION
- Added new method broadcastToTargets() in BroadcastService
- Supports broadcasting to specific sessions via SessionRegistry
- Ensures consistent message format: [#roomId] User: Message
- Added comprehensive unit tests for room broadcast (4 new tests)
- Verified backward compatibility with existing BroadcastService methods