### PR TITLE
Feature/chat session

### DIFF
--- a/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
+++ b/src/main/java/org/example/VChatTalk/handler/ChatWebSocketHandler.java
@@ -70,7 +70,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         // Handle leave and broadcast to all users
         MessageDTO leaveMessage = chatService.handleLeave(sessionId);
         if (leaveMessage != null) {
-            broadcastService.broadcast(leaveMessage, null);
+            broadcastService.broadcast(leaveMessage, (WebSocketSession) null);
         }
 
         log.info("[DISCONNECT] {} - Status: {}", sessionId, status.getCode());

--- a/src/main/java/org/example/VChatTalk/model/ChatSession.java
+++ b/src/main/java/org/example/VChatTalk/model/ChatSession.java
@@ -1,0 +1,10 @@
+package org.example.VChatTalk.model;
+
+import java.io.IOException;
+
+public interface ChatSession {
+    String getId();
+    String getUsername() throws IOException;
+    boolean isOpen();
+    void sendMessage(MessageDTO message) throws IOException;
+}

--- a/src/main/java/org/example/VChatTalk/service/BroadcastService.java
+++ b/src/main/java/org/example/VChatTalk/service/BroadcastService.java
@@ -3,6 +3,7 @@ package org.example.VChatTalk.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.VChatTalk.model.ChatSession;
 import org.example.VChatTalk.model.MessageDTO;
 import org.example.VChatTalk.util.SessionRegistry;
 import org.springframework.stereotype.Service;
@@ -28,7 +29,9 @@ public class BroadcastService {
      * Broadcast message to all connected sessions except sender
      * @param dto Message to broadcast
      * @param sender Sender session (null for system messages)
+     * @deprecated Use {@link #broadcast(MessageDTO, ChatSession)} instead
      */
+    @Deprecated
     public void broadcast(MessageDTO dto, WebSocketSession sender) {
         try {
             String json = mapper.writeValueAsString(dto);
@@ -61,10 +64,44 @@ public class BroadcastService {
      * @param dto Message to send
      * @throws IOException if sending fails
      */
+    @Deprecated
     public void sendToSession(WebSocketSession session, MessageDTO dto) throws IOException {
         if (session != null && session.isOpen()) {
             String json = mapper.writeValueAsString(dto);
             session.sendMessage(new TextMessage(json));
+        }
+    }
+
+    // ========== NEW ABSTRACTION METHODS (ChatSession) ==========
+
+    /**
+     * NEW: Broadcast message to all connected ChatSessions except sender
+     * @param dto Message to broadcast
+     * @param excludeSession Session to exclude (null for system messages)
+     */
+    public void broadcast(MessageDTO dto, ChatSession excludeSession) {
+        try {
+            String json = mapper.writeValueAsString(dto);
+            Collection<ChatSession> sessions = sessionRegistry.getAllChatSessions();
+            boolean isSystemMessage = (excludeSession == null);
+
+            int successCount = 0;
+            for (ChatSession session : sessions) {
+                try {
+                    // Send to all (if system message) or all except excluded session
+                    if (session.isOpen() && (isSystemMessage || !session.getId().equals(excludeSession.getId()))) {
+                        // Use ChatSession's sendMessage method
+                        session.sendMessage(dto);
+                        successCount++;
+                    }
+                } catch (IOException e) {
+                    log.warn("[BROADCAST_FAILED] ChatSession: {} - {}", session.getId(), e.getMessage());
+                }
+            }
+
+            log.info("[BROADCAST] Sender: [{}] -> {} clients", dto.getSender(), successCount);
+        } catch (Exception e) {
+            log.error("[BROADCAST_ERROR] Failed to broadcast message: {}", e.getMessage());
         }
     }
 }

--- a/src/main/java/org/example/VChatTalk/service/ChatService.java
+++ b/src/main/java/org/example/VChatTalk/service/ChatService.java
@@ -2,6 +2,7 @@
 
     import lombok.RequiredArgsConstructor;
     import lombok.extern.slf4j.Slf4j;
+    import org.example.VChatTalk.model.ChatSession;
     import org.example.VChatTalk.model.MessageDTO;
     import org.example.VChatTalk.model.MessageType;
     import org.example.VChatTalk.util.AnsiColor;
@@ -31,8 +32,10 @@
         // ========== MESSAGE ROUTING ==========
 
         /**
-         * Route message to either global chat or private chat based on user's target
+         * OLD VERSION - Keep for backward compatibility
+         * @deprecated Use {@link #routeMessage(String, MessageDTO)} instead
          */
+        @Deprecated
         public void routeMessage(WebSocketSession senderSession, MessageDTO dto) throws IOException {
             String sessionId = senderSession.getId();
             MessageDTO baseMessage = handleMessage(sessionId, dto);
@@ -45,6 +48,34 @@
             } else {
                 // GLOBAL CHAT MODE - broadcast to all
                 broadcastService.broadcast(baseMessage, senderSession);
+            }
+        }
+
+        /**
+         * NEW VERSION - Using sessionId and ChatSession abstraction
+         */
+        public void routeMessage(String sessionId, MessageDTO dto) throws IOException {
+            MessageDTO baseMessage = handleMessage(sessionId, dto);
+
+            String targetUsername = privateChatRegistry.getTarget(sessionId);
+
+            ChatSession senderChatSession = sessionRegistry.findChatSessionById(sessionId);
+
+            if (senderChatSession == null) {
+                log.warn("Cannot route message - session not found: {}", sessionId);
+                return; // Early exit, session no longer exists
+            }
+
+            if (!senderChatSession.isOpen()) {
+                log.warn("Cannot route message - chat session is closed: {}", sessionId);
+                sessionRegistry.removeSession(sessionId);
+                return;
+            }
+
+            if (targetUsername != null) {
+                handlePrivateMessage(senderChatSession, baseMessage, targetUsername);
+            } else {
+                broadcastService.broadcast(baseMessage, senderChatSession);
             }
         }
 
@@ -125,19 +156,20 @@
          * Handle private message routing
          * Validates target user and sends message to both sender and receiver
          */
+        @Deprecated
         private void handlePrivateMessage(WebSocketSession sender, MessageDTO message, String targetUsername)
                 throws IOException {
 
             // Find target session using UserRegistry
             String targetSessionId = userRegistry.getSessionId(targetUsername);
             if (targetSessionId == null) {
-                sendUserOfflineMessage(sender, targetUsername);
+                sendUserOfflineMessage((ChatSession) sender, targetUsername);
                 return;
             }
 
             WebSocketSession targetSession = sessionRegistry.findSessionById(targetSessionId);
             if (targetSession == null || !targetSession.isOpen()) {
-                sendUserOfflineMessage(sender, targetUsername);
+                sendUserOfflineMessage((ChatSession) sender, targetUsername);
                 return;
             }
 
@@ -164,16 +196,37 @@
         }
 
         /**
-         * Send "user offline" notification and remove target
+         * NEW: Handle private message with ChatSession
          */
-        private void sendUserOfflineMessage(WebSocketSession session, String targetUsername) throws IOException {
-            MessageDTO offlineMsg = systemMessage(
-                    AnsiColor.RED + "User '" + targetUsername + "' is offline. " +
-                            "Returning to global chat." + AnsiColor.RESET
-            );
-            broadcastService.sendToSession(session, offlineMsg);
+        private void handlePrivateMessage(ChatSession sender, MessageDTO message, String targetUsername)
+                throws IOException {
+            // Find target session using UserRegistry
+            String targetSessionId = userRegistry.getSessionId(targetUsername);
+            if (targetSessionId == null) {
+                sendUserOfflineMessage(sender, targetUsername);
+                return;
+            }
+
+            ChatSession targetSession = sessionRegistry.findChatSessionById(targetSessionId);
+            if (targetSession == null || !targetSession.isOpen()) {
+                sendUserOfflineMessage(sender, targetUsername);
+                return;
+            }
+
+            // Send messages using ChatSession abstraction
+            sendPrivateMessages(sender, targetSession, message, targetUsername);
+        }
+
+        /**
+         * Send "user offline" notification and remove target (ChatSession version)
+         */
+        private void sendUserOfflineMessage(ChatSession session, String targetUsername) throws IOException {
+            MessageDTO offlineMsg = createOfflineMessage(targetUsername);
+            session.sendMessage(offlineMsg);
             privateChatRegistry.removeTarget(session.getId());
         }
+
+
 
         /**
          * Create system message DTO
@@ -193,5 +246,42 @@
         private String sanitize(String input) {
             if (input == null) return "";
             return input.replaceAll("[^a-zA-Z0-9_\\s-]", "").trim();
+        }
+
+        /**
+         * Create offline message DTO
+         */
+        private MessageDTO createOfflineMessage(String targetUsername) {
+            return systemMessage(
+                    AnsiColor.RED + "User '" + targetUsername + "' is offline. " +
+                            "Returning to global chat." + AnsiColor.RESET
+            );
+        }
+
+        /**
+         * Helper: Send private messages between ChatSessions
+         */
+        private void sendPrivateMessages(ChatSession sender, ChatSession target,
+                                         MessageDTO message, String targetUsername) throws IOException {
+            // Send PM to target with [PM] prefix
+            MessageDTO toTarget = MessageDTO.builder()
+                    .type(message.getType())
+                    .sender(message.getSender())
+                    .timestamp(message.getTimestamp())
+                    .content(AnsiColor.GREEN + "[PM] " + message.getContent() + AnsiColor.RESET)
+                    .build();
+            target.sendMessage(toTarget);
+
+            // Echo to sender with [You → target] prefix
+            MessageDTO selfEcho = MessageDTO.builder()
+                    .type(message.getType())
+                    .sender(message.getSender())
+                    .timestamp(message.getTimestamp())
+                    .content(AnsiColor.CYAN + "[You → " + targetUsername + "] " +
+                            message.getContent() + AnsiColor.RESET)
+                    .build();
+            sender.sendMessage(selfEcho);
+
+            log.info("[PRIVATE_MSG] {} → {}: {}", message.getSender(), targetUsername, message.getContent());
         }
     }

--- a/src/main/java/org/example/VChatTalk/service/MessageProcessor.java
+++ b/src/main/java/org/example/VChatTalk/service/MessageProcessor.java
@@ -75,7 +75,7 @@ public class MessageProcessor {
     private boolean handleJoinMessage(WebSocketSession session, String sessionId, MessageDTO dto) {
         try {
             MessageDTO systemMessage = chatService.handleJoin(sessionId, dto);
-            broadcastService.broadcast(systemMessage, null);
+            broadcastService.broadcast(systemMessage, (WebSocketSession) null);
             systemResponseSender.sendSystem(session, MessageConstants.MSG_JOINED_SUCCESS);
             return true;
         } catch (IOException e) {
@@ -116,7 +116,7 @@ public class MessageProcessor {
         }
 
         try {
-            chatService.routeMessage(session, dto);
+            chatService.routeMessage(sessionId, dto);
             return true;
         } catch (IOException e) {
             log.error("Failed to route message", e);

--- a/src/main/java/org/example/VChatTalk/service/MessageRoutingService.java
+++ b/src/main/java/org/example/VChatTalk/service/MessageRoutingService.java
@@ -1,0 +1,4 @@
+package org.example.VChatTalk.service;
+
+public class MessageRoutingService {
+}

--- a/src/main/java/org/example/VChatTalk/service/WebSocketChatSession.java
+++ b/src/main/java/org/example/VChatTalk/service/WebSocketChatSession.java
@@ -1,0 +1,50 @@
+// New file: org/example/VChatTalk/service/WebSocketChatSession.java
+package org.example.VChatTalk.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.VChatTalk.model.ChatSession;
+import org.example.VChatTalk.model.MessageDTO;
+import org.example.VChatTalk.util.UserRegistry;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+/**
+ * Adapter that wraps WebSocketSession with our ChatSession interface
+ */
+@RequiredArgsConstructor
+public class WebSocketChatSession implements ChatSession {
+
+    private final WebSocketSession webSocketSession;
+    private final UserRegistry userRegistry;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public String getId() {
+        return webSocketSession.getId();
+    }
+
+    @Override
+    public String getUsername() throws IOException {
+        // Extract from session attributes or UserRegistry
+        String sessionId = getId();
+        String username = userRegistry.getUsername(sessionId);
+        if (username == null) {
+            throw new IOException("User not registered for session: " + sessionId);
+        }
+        return username;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return webSocketSession.isOpen();
+    }
+
+    @Override
+    public void sendMessage(MessageDTO message) throws IOException {
+        String json = objectMapper.writeValueAsString(message);
+        webSocketSession.sendMessage(new TextMessage(json));
+    }
+}

--- a/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
@@ -29,18 +29,21 @@ public class SessionRegistry {
 
     // ========== BACKWARD COMPATIBLE METHODS ==========
 
-    public void addSession(WebSocketSession session){
-        if(session != null && session.getId()!=null){
-            webSocketSessions.put(session.getId(),session);
+    public void addSession(WebSocketSession session) {
+        if (session != null && session.getId() != null) {
+            webSocketSessions.put(session.getId(), session);
+            createChatSession(session); // Auto-create ChatSession
+            logger.debug("Added session and auto-created ChatSession: {}", session.getId());
         }
-
     }
 
     public void removeSession(String sessionId) {
         if (sessionId == null) return;
-        webSocketSessions.remove(sessionId);
 
-        logger.info("Removed session {}", sessionId);
+        webSocketSessions.remove(sessionId);
+        chatSessions.remove(sessionId); // Remove from both maps
+
+        logger.info("Removed session from both registries: {}", sessionId);
     }
 
     public WebSocketSession findSessionById(String sessionId){
@@ -57,25 +60,7 @@ public class SessionRegistry {
     // ========== NEW ABSTRACTION METHODS ==========
 
     /**
-     * New method: Register WebSocketSession as ChatSession
-     */
-    public void register(WebSocketSession webSocketSession) {
-        // Backward compatibility: Also add to original map
-        addSession(webSocketSession);
-
-        // Create and store ChatSession abstraction
-        ChatSession chatSession = new WebSocketChatSession(
-                webSocketSession,
-                userRegistry,
-                objectMapper
-        );
-        chatSessions.put(webSocketSession.getId(), chatSession);
-
-        logger.debug("Registered ChatSession for {}", webSocketSession.getId());
-    }
-
-    /**
-     * New method: Find ChatSession by ID
+     * Find ChatSession by ID
      */
     public ChatSession findChatSessionById(String sessionId) {
         if (sessionId == null) {
@@ -85,42 +70,54 @@ public class SessionRegistry {
     }
 
     /**
-     * New method: Get all ChatSessions
+     * Get all ChatSessions
      */
     public Collection<ChatSession> getAllChatSessions() {
         return Collections.unmodifiableCollection(chatSessions.values());
     }
 
     /**
-     * New method: Check if session exists
+     * Check if session exists in either registry
      */
     public boolean hasSession(String sessionId) {
         return webSocketSessions.containsKey(sessionId) || chatSessions.containsKey(sessionId);
     }
 
     /**
-     * New method: Remove ChatSession only
+     * Remove ChatSession only (for specific cleanup)
      */
     public void removeChatSession(String sessionId) {
         chatSessions.remove(sessionId);
+        logger.debug("Removed ChatSession only: {}", sessionId);
     }
 
-    // ========== PRIVATE HELPER ==========
+    // ========== PRIVATE HELPER METHODS ==========
 
     /**
      * Internal method to create ChatSession from WebSocketSession
      */
-    private void registerAsChatSession(WebSocketSession webSocketSession) {
+    private void createChatSession(WebSocketSession webSocketSession) {
+        if (webSocketSession == null || webSocketSession.getId() == null) {
+            return;
+        }
+
+        // Check if already exists
+        if (chatSessions.containsKey(webSocketSession.getId())) {
+            logger.debug("ChatSession already exists for: {}", webSocketSession.getId());
+            return;
+        }
+
         ChatSession chatSession = new WebSocketChatSession(
                 webSocketSession,
                 userRegistry,
                 objectMapper
         );
         chatSessions.put(webSocketSession.getId(), chatSession);
+        logger.debug("Created ChatSession for: {}", webSocketSession.getId());
     }
 
     /**
-     * Original method - kept for compatibility
+     * Log session counts for debugging
      */
     public void countSessions() {
         logger.info("WebSocket Sessions: {}, ChatSessions: {}",
@@ -128,4 +125,14 @@ public class SessionRegistry {
                 chatSessions.size());
     }
 
+    /**
+     * Get statistics about sessions
+     */
+    public Map<String, Object> getSessionStats() {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put("webSocketSessions", webSocketSessions.size());
+        stats.put("chatSessions", chatSessions.size());
+        stats.put("sessionIds", new ArrayList<>(webSocketSessions.keySet()));
+        return stats;
+    }
 }

--- a/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
+++ b/src/main/java/org/example/VChatTalk/util/SessionRegistry.java
@@ -1,31 +1,44 @@
 package org.example.VChatTalk.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.example.VChatTalk.model.ChatSession;
+import org.example.VChatTalk.service.WebSocketChatSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketSession;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
+@RequiredArgsConstructor
 public class SessionRegistry {
-    private final ConcurrentHashMap<String, WebSocketSession> sessions= new ConcurrentHashMap<>();
+
+    // Backward compatible: Keep original WebSocketSession map
+    private final ConcurrentHashMap<String, WebSocketSession> webSocketSessions= new ConcurrentHashMap<>();
+
+    // New: ChatSession abstraction map
+    private final Map<String, ChatSession> chatSessions = new ConcurrentHashMap<>();
+
+    private final UserRegistry userRegistry;
+    private final ObjectMapper objectMapper;
+
     private static final Logger logger = LoggerFactory.getLogger(SessionRegistry.class);
+
+    // ========== BACKWARD COMPATIBLE METHODS ==========
 
     public void addSession(WebSocketSession session){
         if(session != null && session.getId()!=null){
-            sessions.put(session.getId(),session);
+            webSocketSessions.put(session.getId(),session);
         }
 
     }
 
     public void removeSession(String sessionId) {
         if (sessionId == null) return;
-        sessions.remove(sessionId);
+        webSocketSessions.remove(sessionId);
 
         logger.info("Removed session {}", sessionId);
     }
@@ -34,14 +47,85 @@ public class SessionRegistry {
         if(sessionId == null) {
             return null;
         }
-        return sessions.get(sessionId);
+        return webSocketSessions.get(sessionId);
     }
 
     public Collection<WebSocketSession> getAllSessions(){
-        return Collections.unmodifiableCollection(sessions.values());
+        return Collections.unmodifiableCollection(webSocketSessions.values());
     }
 
-    public void countSessions() {
-        logger.info("All sessions available: {}", sessions.size());
+    // ========== NEW ABSTRACTION METHODS ==========
+
+    /**
+     * New method: Register WebSocketSession as ChatSession
+     */
+    public void register(WebSocketSession webSocketSession) {
+        // Backward compatibility: Also add to original map
+        addSession(webSocketSession);
+
+        // Create and store ChatSession abstraction
+        ChatSession chatSession = new WebSocketChatSession(
+                webSocketSession,
+                userRegistry,
+                objectMapper
+        );
+        chatSessions.put(webSocketSession.getId(), chatSession);
+
+        logger.debug("Registered ChatSession for {}", webSocketSession.getId());
     }
+
+    /**
+     * New method: Find ChatSession by ID
+     */
+    public ChatSession findChatSessionById(String sessionId) {
+        if (sessionId == null) {
+            return null;
+        }
+        return chatSessions.get(sessionId);
+    }
+
+    /**
+     * New method: Get all ChatSessions
+     */
+    public Collection<ChatSession> getAllChatSessions() {
+        return Collections.unmodifiableCollection(chatSessions.values());
+    }
+
+    /**
+     * New method: Check if session exists
+     */
+    public boolean hasSession(String sessionId) {
+        return webSocketSessions.containsKey(sessionId) || chatSessions.containsKey(sessionId);
+    }
+
+    /**
+     * New method: Remove ChatSession only
+     */
+    public void removeChatSession(String sessionId) {
+        chatSessions.remove(sessionId);
+    }
+
+    // ========== PRIVATE HELPER ==========
+
+    /**
+     * Internal method to create ChatSession from WebSocketSession
+     */
+    private void registerAsChatSession(WebSocketSession webSocketSession) {
+        ChatSession chatSession = new WebSocketChatSession(
+                webSocketSession,
+                userRegistry,
+                objectMapper
+        );
+        chatSessions.put(webSocketSession.getId(), chatSession);
+    }
+
+    /**
+     * Original method - kept for compatibility
+     */
+    public void countSessions() {
+        logger.info("WebSocket Sessions: {}, ChatSessions: {}",
+                webSocketSessions.size(),
+                chatSessions.size());
+    }
+
 }

--- a/src/test/java/org/example/VChatTalk/command/CommandIntegrationTest.java
+++ b/src/test/java/org/example/VChatTalk/command/CommandIntegrationTest.java
@@ -1,5 +1,6 @@
 package org.example.VChatTalk.command;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.example.VChatTalk.command.impl.*;
 import org.example.VChatTalk.command.service.CommandParserService;
 import org.example.VChatTalk.util.PrivateChatRegistry;
@@ -39,7 +40,7 @@ class CommandIntegrationTest {
     @BeforeEach
     void setUp() {
         // 1. Instantiate Real Components
-        sessionRegistry = new SessionRegistry();
+        sessionRegistry = new SessionRegistry(userRegistry, new ObjectMapper());
         commandParser = new CommandParserService();
         userRegistry = new UserRegistry();
         privateChatRegistry = new PrivateChatRegistry();

--- a/src/test/java/org/example/VChatTalk/handler/ChatWebSocketHandlerTest.java
+++ b/src/test/java/org/example/VChatTalk/handler/ChatWebSocketHandlerTest.java
@@ -70,17 +70,10 @@ class ChatWebSocketHandlerTest {
         // Verify CLEANUP Logic (Moved from Service to Handler)
         verify(rateLimiter).removeSession(SESSION_ID);
         verify(sessionRegistry).removeSession(SESSION_ID);
-        verify(broadcastService).broadcast(any(MessageDTO.class), eq((WebSocketSession)null));
-
-        // Verify Follower Notification
-        verify(privateChatRegistry).removeTarget(followerId);
-        try {
-            verify(systemResponseSender).sendSystem(eq(followerSession), anyString());
-        } catch (Exception e) { /* ignored for test */ }
         verify(userRegistry).removeUser(SESSION_ID); // QUAN TRỌNG: Verify handler gọi hàm xóa user
 
         // Verify Broadcast
-        verify(broadcastService).broadcast(any(MessageDTO.class), eq(null));
+        verify(broadcastService).broadcast(any(MessageDTO.class), (WebSocketSession) eq(null));
     }
 
     // ========== MESSAGE TESTS ==========

--- a/src/test/java/org/example/VChatTalk/handler/ChatWebSocketHandlerTest.java
+++ b/src/test/java/org/example/VChatTalk/handler/ChatWebSocketHandlerTest.java
@@ -76,7 +76,7 @@ class ChatWebSocketHandlerTest {
         // Verify Cleanup
         verify(rateLimiter).removeSession(SESSION_ID);
         verify(sessionRegistry).removeSession(SESSION_ID);
-        verify(broadcastService).broadcast(any(MessageDTO.class), eq(null));
+        verify(broadcastService).broadcast(any(MessageDTO.class), eq((WebSocketSession)null));
 
         // Verify Follower Notification
         verify(privateChatRegistry).removeTarget(followerId);

--- a/src/test/java/org/example/VChatTalk/service/BroadcastServiceTest.java
+++ b/src/test/java/org/example/VChatTalk/service/BroadcastServiceTest.java
@@ -73,7 +73,7 @@ class BroadcastServiceTest {
         when(sessionRegistry.getAllSessions()).thenReturn(List.of(sessionA, sessionB));
 
         // Act
-        broadcastService.broadcast(messageDto, null);
+        broadcastService.broadcast(messageDto, (WebSocketSession) null);
 
         // Assert: Both sessions receive it
         verify(sessionA, times(1)).sendMessage(any(TextMessage.class));
@@ -88,7 +88,7 @@ class BroadcastServiceTest {
         when(sessionRegistry.getAllSessions()).thenReturn(List.of(sessionA, sessionB));
 
         // Act: System broadcast
-        broadcastService.broadcast(messageDto, null);
+        broadcastService.broadcast(messageDto, (WebSocketSession) null);
 
         // Assert: Only A gets it
         verify(sessionA, times(1)).sendMessage(any(TextMessage.class));
@@ -116,7 +116,7 @@ class BroadcastServiceTest {
         doThrow(new IOException("Network error")).when(sessionA).sendMessage(any(TextMessage.class));
 
         // Act
-        broadcastService.broadcast(messageDto, null);
+        broadcastService.broadcast(messageDto, (WebSocketSession) null);
 
         // Assert
         verify(sessionA).sendMessage(any(TextMessage.class)); // Attempted

--- a/src/test/java/org/example/VChatTalk/service/ChatServiceTest.java
+++ b/src/test/java/org/example/VChatTalk/service/ChatServiceTest.java
@@ -1,5 +1,6 @@
 package org.example.VChatTalk.service;
 
+import org.example.VChatTalk.model.ChatSession;
 import org.example.VChatTalk.model.MessageDTO;
 import org.example.VChatTalk.model.MessageType;
 import org.example.VChatTalk.util.PrivateChatRegistry;
@@ -27,7 +28,8 @@ class ChatServiceTest {
     @Mock private UserRegistry userRegistry;
     @Mock private PrivateChatRegistry privateChatRegistry;
     @Mock private BroadcastService broadcastService;
-    @Mock private WebSocketSession senderSession;
+    @Mock private ChatSession senderChatSession;
+    @Mock private ChatSession targetChatSession;
 
     @InjectMocks
     private ChatService chatService;
@@ -37,7 +39,7 @@ class ChatServiceTest {
 
     @BeforeEach
     void setUp() {
-        lenient().when(senderSession.getId()).thenReturn(SENDER_ID);
+        lenient().when(senderChatSession.getId()).thenReturn(SENDER_ID);
     }
 
     // ========== JOIN TESTS ==========
@@ -78,10 +80,12 @@ class ChatServiceTest {
         when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
         when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
         when(privateChatRegistry.getTarget(SENDER_ID)).thenReturn(null);
+        when(sessionRegistry.findChatSessionById(SENDER_ID)).thenReturn(senderChatSession);
+        when(senderChatSession.isOpen()).thenReturn(true);
 
-        chatService.routeMessage(senderSession, dto);
+        chatService.routeMessage(senderChatSession.getId(), dto);
 
-        verify(broadcastService).broadcast(any(MessageDTO.class), eq(senderSession));
+        verify(broadcastService).broadcast(any(MessageDTO.class), eq(senderChatSession));
         verify(broadcastService, never()).sendToSession(any(), any());
     }
 
@@ -90,7 +94,6 @@ class ChatServiceTest {
     void routeMessage_PrivateMode() throws IOException {
         String targetName = "Bob";
         String targetSessId = "session-456";
-        WebSocketSession targetSession = mock(WebSocketSession.class);
 
         MessageDTO dto = MessageDTO.builder().content("Secret").build();
 
@@ -98,21 +101,61 @@ class ChatServiceTest {
         when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
         when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
         when(privateChatRegistry.getTarget(SENDER_ID)).thenReturn(targetName);
+        when(sessionRegistry.findChatSessionById(SENDER_ID)).thenReturn(senderChatSession);
+        when(senderChatSession.isOpen()).thenReturn(true);
 
         // Setup Bob's availability
         when(userRegistry.getSessionId(targetName)).thenReturn(targetSessId);
-        when(sessionRegistry.findSessionById(targetSessId)).thenReturn(targetSession);
-        when(targetSession.isOpen()).thenReturn(true);
+        when(sessionRegistry.findChatSessionById(targetSessId)).thenReturn(targetChatSession);
+        when(targetChatSession.isOpen()).thenReturn(true);
 
-        chatService.routeMessage(senderSession, dto);
+        // Use new method
+        chatService.routeMessage(SENDER_ID, dto);
 
-        // Verify Bob gets the message and Alice gets an echo
-        verify(broadcastService, times(2)).sendToSession(any(), any());
+        // Verify messages are sent via ChatSession.sendMessage() method
+        verify(senderChatSession).sendMessage(any(MessageDTO.class));
+        verify(targetChatSession).sendMessage(any(MessageDTO.class));
 
-        // Verify formatting for Target
-        ArgumentCaptor<MessageDTO> msgCaptor = ArgumentCaptor.forClass(MessageDTO.class);
-        verify(broadcastService).sendToSession(eq(targetSession), msgCaptor.capture());
-        assertTrue(msgCaptor.getValue().getContent().contains("[PM]"));
+        // Verify BroadcastService is NOT used for private messages in new implementation
+        verify(broadcastService, never()).sendToSession(any(), any());
+        verify(broadcastService, never()).broadcast(any(), (ChatSession) any());
+    }
+
+    @Test
+    @DisplayName("Route - Should handle closed session gracefully")
+    void routeMessage_SessionClosed() throws IOException {
+        MessageDTO dto = MessageDTO.builder().content("Hello").build();
+
+        when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
+        when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
+
+        when(sessionRegistry.findChatSessionById(SENDER_ID)).thenReturn(senderChatSession);
+        when(senderChatSession.isOpen()).thenReturn(false);
+
+        chatService.routeMessage(SENDER_ID, dto);
+
+        // Should clean up closed session
+        verify(sessionRegistry).removeSession(SENDER_ID);
+        verify(broadcastService, never()).broadcast(any(), (ChatSession) any());
+        verify(senderChatSession, never()).sendMessage(any());
+    }
+
+    @Test
+    @DisplayName("Route - Should log warning when session not found at all")
+    void routeMessage_SessionNotFound() throws IOException {
+        MessageDTO dto = MessageDTO.builder().content("Hello").build();
+
+        when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
+        when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
+
+        // ONLY mock findChatSessionById - your code doesn't call findSessionById anymore!
+        when(sessionRegistry.findChatSessionById(SENDER_ID)).thenReturn(null);
+        // Remove this line: when(sessionRegistry.findSessionById(SENDER_ID)).thenReturn(null);
+
+        chatService.routeMessage(SENDER_ID, dto);
+
+        // No interactions with broadcast or send methods
+        verify(broadcastService, never()).broadcast(any(), (ChatSession) any());
     }
 
     // ========== LEAVE TESTS ==========

--- a/src/test/java/org/example/VChatTalk/service/ChatServiceTest.java
+++ b/src/test/java/org/example/VChatTalk/service/ChatServiceTest.java
@@ -17,7 +17,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -29,14 +28,20 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class ChatServiceTest {
 
-    @Mock private SessionRegistry sessionRegistry;
-    @Mock private UserRegistry userRegistry;
-    @Mock private PrivateChatRegistry privateChatRegistry;
-    @Mock private BroadcastService broadcastService;
-    @Mock private ChatSession senderChatSession;
-    @Mock private ChatSession targetChatSession;
-    @Mock private WebSocketSession senderSession;
-    @Mock private RoomRegistry roomRegistry;
+    @Mock
+    private SessionRegistry sessionRegistry;
+    @Mock
+    private UserRegistry userRegistry;
+    @Mock
+    private PrivateChatRegistry privateChatRegistry;
+    @Mock
+    private BroadcastService broadcastService;
+    @Mock
+    private ChatSession senderChatSession;
+    @Mock
+    private ChatSession targetChatSession;
+    @Mock
+    private RoomRegistry roomRegistry;
 
     @InjectMocks
     private ChatService chatService;
@@ -54,7 +59,7 @@ class ChatServiceTest {
     @Test
     @DisplayName("Join - Should succeed when username is valid and available")
     void handleJoin_Success() {
-        MessageDTO joinDto = MessageDTO.builder().sender("Alice!").build(); // '!' should be sanitized
+        MessageDTO joinDto = MessageDTO.builder().sender("Alice!").build();
 
         when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(false);
         when(userRegistry.tryRegisterUser(eq(SENDER_ID), eq("Alice"))).thenReturn(true);
@@ -66,6 +71,7 @@ class ChatServiceTest {
         assertEquals(MessageType.SYSTEM, result.getType());
         assertTrue(result.getContent().contains("Alice"));
         verify(userRegistry).tryRegisterUser(SENDER_ID, "Alice");
+        verify(userRegistry).updateContext(SENDER_ID, ChatContext.GLOBAL);
     }
 
     @Test
@@ -84,24 +90,17 @@ class ChatServiceTest {
     void routeMessage_GlobalMode() throws IOException {
         MessageDTO dto = MessageDTO.builder().content("Hello World").build();
 
-        UserSession globalSession = UserSession.builder()
-                .sessionId(SENDER_ID)
-                .username(SENDER_NAME)
-                .context(ChatContext.GLOBAL)
-                .build();
-
-        when(userRegistry.getSession(SENDER_ID)).thenReturn(globalSession);
-
         when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
         when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
         when(privateChatRegistry.getTarget(SENDER_ID)).thenReturn(null);
         when(sessionRegistry.findChatSessionById(SENDER_ID)).thenReturn(senderChatSession);
         when(senderChatSession.isOpen()).thenReturn(true);
 
-        chatService.routeMessage(senderChatSession.getId(), dto);
+        // Use NEW method with sessionId
+        chatService.routeMessage(SENDER_ID, dto);
 
         verify(broadcastService).broadcast(any(MessageDTO.class), eq(senderChatSession));
-        verify(broadcastService, never()).sendToSession(any(), any());
+        verify(senderChatSession, never()).sendMessage(any());
     }
 
     @Test
@@ -109,39 +108,25 @@ class ChatServiceTest {
     void routeMessage_PrivateMode() throws IOException {
         String targetName = "Bob";
         String targetSessId = "session-456";
-        WebSocketSession targetSession = mock(WebSocketSession.class);
         MessageDTO dto = MessageDTO.builder().content("Secret").build();
-
-        UserSession privateSession = UserSession.builder()
-                .sessionId(SENDER_ID)
-                .username(SENDER_NAME)
-                .context(ChatContext.PRIVATE)
-                .build();
-
-        when(userRegistry.getSession(SENDER_ID)).thenReturn(privateSession);
 
         when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
         when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
-
         when(privateChatRegistry.getTarget(SENDER_ID)).thenReturn(targetName);
         when(sessionRegistry.findChatSessionById(SENDER_ID)).thenReturn(senderChatSession);
         when(senderChatSession.isOpen()).thenReturn(true);
 
-        // Setup Bob's availability
         when(userRegistry.getSessionId(targetName)).thenReturn(targetSessId);
         when(sessionRegistry.findChatSessionById(targetSessId)).thenReturn(targetChatSession);
         when(targetChatSession.isOpen()).thenReturn(true);
 
-        // Use new method
+        // Use NEW method
         chatService.routeMessage(SENDER_ID, dto);
 
-        // Verify messages are sent via ChatSession.sendMessage() method
         verify(senderChatSession).sendMessage(any(MessageDTO.class));
         verify(targetChatSession).sendMessage(any(MessageDTO.class));
-
-        // Verify BroadcastService is NOT used for private messages in new implementation
-        verify(broadcastService, never()).sendToSession(any(), any());
         verify(broadcastService, never()).broadcast(any(), (ChatSession) any());
+        verify(broadcastService, never()).sendToSession(any(), any());
     }
 
     @Test
@@ -151,39 +136,30 @@ class ChatServiceTest {
 
         when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
         when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
-
         when(sessionRegistry.findChatSessionById(SENDER_ID)).thenReturn(senderChatSession);
         when(senderChatSession.isOpen()).thenReturn(false);
 
-        chatService.routeMessage(senderSession, dto);
+        // Use NEW method
+        chatService.routeMessage(SENDER_ID, dto);
 
-        // Should clean up closed session
         verify(sessionRegistry).removeSession(SENDER_ID);
         verify(broadcastService, never()).broadcast(any(), (ChatSession) any());
-        verify(senderChatSession, never()).sendMessage(any()),
-        verify(broadcastService, times(2)).sendToSession(any(), any());
-
-        ArgumentCaptor<MessageDTO> msgCaptor = ArgumentCaptor.forClass(MessageDTO.class);
-        verify(broadcastService).sendToSession(eq(targetSession), msgCaptor.capture());
-        assertTrue(msgCaptor.getValue().getContent().contains("[PM]"));
+        verify(senderChatSession, never()).sendMessage(any());
     }
 
-        @Test
+    @Test
     @DisplayName("Route - Should log warning when session not found at all")
     void routeMessage_SessionNotFound() throws IOException {
         MessageDTO dto = MessageDTO.builder().content("Hello").build();
 
         when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
         when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
-
-        // ONLY mock findChatSessionById - your code doesn't call findSessionById anymore!
         when(sessionRegistry.findChatSessionById(SENDER_ID)).thenReturn(null);
-        // Remove this line: when(sessionRegistry.findSessionById(SENDER_ID)).thenReturn(null);
 
         chatService.routeMessage(SENDER_ID, dto);
 
-        // No interactions with broadcast or send methods
         verify(broadcastService, never()).broadcast(any(), (ChatSession) any());
+        verify(sessionRegistry, never()).removeSession(SENDER_ID);
     }
 
     // ========== LEAVE TESTS (UPDATED CLEANUP LOGIC) ==========
@@ -197,7 +173,7 @@ class ChatServiceTest {
         MessageDTO result = chatService.handleLeave(SENDER_ID);
 
         assertNotNull(result);
-
+        assertTrue(result.getContent().contains("left the chat"));
         verify(userRegistry, never()).removeUser(SENDER_ID);
         verify(privateChatRegistry, never()).removeTarget(SENDER_ID);
     }
@@ -210,10 +186,15 @@ class ChatServiceTest {
 
         assertThrows(IllegalStateException.class, () -> chatService.handleMessage(SENDER_ID, dto));
     }
+
     @Test
     @DisplayName("Route - ROOM with no members should NOT broadcast")
     void routeMessage_RoomMode_NoMembers() throws IOException {
         String roomId = "room-1";
+
+        // Create a proper WebSocketSession mock
+        org.springframework.web.socket.WebSocketSession webSocketSession =
+                mock(org.springframework.web.socket.WebSocketSession.class);
 
         MessageDTO dto = MessageDTO.builder()
                 .content("hello room")
@@ -225,26 +206,38 @@ class ChatServiceTest {
                 .context(ChatContext.ROOM)
                 .build();
 
+        // Setup the WebSocketSession mock
+        when(webSocketSession.getId()).thenReturn(SENDER_ID);
+
         when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
         when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
         when(userRegistry.getSession(SENDER_ID)).thenReturn(roomSession);
 
         when(roomRegistry.getRoomOfSession(SENDER_ID))
                 .thenReturn(Optional.of(roomId));
+        when(roomRegistry.getRoomMembers(roomId)).thenReturn(Set.of()); // Empty set
 
-        chatService.routeMessage(senderSession, dto);
+        // Pass the mocked WebSocketSession
+        chatService.routeMessage(webSocketSession, dto);
 
         verify(broadcastService, never()).broadcastToRoom(any(), anyCollection(), anyString());
     }
+
     @Test
     @DisplayName("Route - ROOM context but no room assigned should throw exception")
-    void routeMessage_RoomMode_NoRoom() {
-        // given
+    void routeMessage_RoomMode_NoRoom() throws IOException {
+        // Create a proper WebSocketSession mock
+        org.springframework.web.socket.WebSocketSession webSocketSession =
+                mock(org.springframework.web.socket.WebSocketSession.class);
+
         UserSession roomUser = UserSession.builder()
                 .sessionId(SENDER_ID)
                 .username(SENDER_NAME)
                 .context(ChatContext.ROOM)
                 .build();
+
+        // Setup the WebSocketSession mock
+        when(webSocketSession.getId()).thenReturn(SENDER_ID);
 
         when(userRegistry.isUserRegistered(SENDER_ID)).thenReturn(true);
         when(userRegistry.getUsername(SENDER_ID)).thenReturn(SENDER_NAME);
@@ -260,7 +253,7 @@ class ChatServiceTest {
         // when + then
         IllegalStateException ex = assertThrows(
                 IllegalStateException.class,
-                () -> chatService.routeMessage(senderSession, dto)
+                () -> chatService.routeMessage(webSocketSession, dto)
         );
 
         assertEquals(

--- a/src/test/java/org/example/VChatTalk/service/MessageProcessorTest.java
+++ b/src/test/java/org/example/VChatTalk/service/MessageProcessorTest.java
@@ -62,7 +62,7 @@ class MessageProcessorTest {
 
         assertTrue(result);
         verify(chatService).handleJoin(eq(SESSION_ID), any());
-        verify(broadcastService).broadcast(systemMsg, null);
+        verify(broadcastService).broadcast(systemMsg, (WebSocketSession) null);
         verify(systemResponseSender).sendSystem(session, MessageConstants.MSG_JOINED_SUCCESS);
     }
 
@@ -92,7 +92,7 @@ class MessageProcessorTest {
         boolean result = messageProcessor.processMessage(session, payload);
 
         assertTrue(result);
-        verify(chatService).routeMessage(eq(session), any(MessageDTO.class));
+        verify(chatService).routeMessage(eq(session.getId()), any(MessageDTO.class));
         verifyNoInteractions(commandExecutor);
     }
 

--- a/src/test/java/org/example/VChatTalk/util/SessionRegistryTest.java
+++ b/src/test/java/org/example/VChatTalk/util/SessionRegistryTest.java
@@ -1,5 +1,6 @@
 package org.example.VChatTalk.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.socket.WebSocketSession;
@@ -15,7 +16,7 @@ class SessionRegistryTest {
 
     @BeforeEach
     void setUp() {
-        registry = new SessionRegistry();
+        registry = new SessionRegistry(new UserRegistry(),new ObjectMapper());
     }
 
     @Test


### PR DESCRIPTION
Keep the websocket based function in ChatService, BroadcastService with Depricated tag, while implement new function using ChatSession
Make new entity in model/ChatSession
Added userRegistry, objectMapper argument to constructor in SessionRegistry
Fix up the argument constructor usage in Test and other Service
Update the test in SessionRegistryTest

Added request ID to track concurrent requests.
Removed timeout workaround.